### PR TITLE
UI/gesture

### DIFF
--- a/ai_modules/cv/gesture_module_API.py
+++ b/ai_modules/cv/gesture_module_API.py
@@ -89,7 +89,7 @@ _pointer_filters = {"Left": _new_pointer_filter(), "Right": _new_pointer_filter(
 
 # ── FSM + Debouncing ─────────────────────────────────────────────────────────
 CONFIRM_FRAMES    = 3    # 일반 정적 제스처 확정 프레임
-CONFIRM_FRAMES_OK = 7    # ok — 연속 7프레임(~0.23초) 유지해야 발화
+CONFIRM_FRAMES_OK = 4    # ok — 규칙 기반이므로 4프레임(~0.13초)으로 단축
 STATIC_COOLDOWN    = 0.8  # 일반 제스처 재인식 대기
 STATIC_COOLDOWN_OK = 0.6  # ok 재인식 대기
 _gesture_state  = {
@@ -107,9 +107,13 @@ _GESTURE_PRIORITY = {
     'finger_4':    1, 'finger_5':    1,
 }
 
-# ── finger_* 신뢰도 임계값 (ok 보다 높게 — 오인식 억제) ────────────────────
-FINGER_CONF_THRESHOLD = 0.85   # finger_1~5
-OK_CONF_THRESHOLD     = 0.9   # ok
+# ── finger_* 신뢰도 임계값 ──────────────────────────────────────────────────
+FINGER_CONF_THRESHOLD = 0.85   # finger_1~5 (ML)
+# ok는 규칙 기반으로 처리하므로 ML 임계값 불필요
+
+# ── 핀치(ok) 규칙 기반 임계값 ───────────────────────────────────────────────
+# 엄지 끝(4) ↔ 검지 끝(8) 3D 거리. 값을 높이면 더 멀어도 인식, 낮추면 더 붙어야 인식.
+PINCH_RULE_THRESHOLD = 0.06
 
 # ── 스와이프 ─────────────────────────────────────────────────────────────────
 SWIPE_MIN_NORM  = 0.12      # ML 기반 사용 시에도 최소 이동 거리 필터
@@ -235,12 +239,16 @@ def _process_one_hand(mp_label, raw_landmarks, w, h):
         raw = _classify_static(landmarks)
         gesture = _confirm_static(mp_label, raw)
 
-    finger_count = _count_fingers(landmarks, mp_label)
+    finger_count  = _count_fingers(landmarks, mp_label)
+    pinch_dist    = round(_pinch_distance(landmarks), 4)
+    pointing      = _is_pointing(landmarks)
 
     return label, {
         "gesture":        gesture,
         "finger_count":   finger_count,
         "index_position": index_pos,
+        "pinch_distance": pinch_dist,   # 엄지 끝 ↔ 검지 끝 정규화 거리
+        "is_pointing":    pointing,     # 검지만 핀 상태 여부
     }
 
 
@@ -334,12 +342,32 @@ def _count_fingers(landmarks, mp_label):
 
 
 def _classify_static(landmarks):
+    # ok(핀치) — 규칙 기반 우선, ML 미사용
+    if _pinch_distance(landmarks) < PINCH_RULE_THRESHOLD:
+        return 'ok'
+
+    # finger_1~5 — ML 분류기
     label, conf = predict_static(landmarks, confidence_threshold=0.0)
-    if label is not None:
-        min_conf = FINGER_CONF_THRESHOLD if label.startswith('finger_') else OK_CONF_THRESHOLD
-        if conf >= min_conf:
+    if label is not None and label != 'ok' and label.startswith('finger_'):
+        if conf >= FINGER_CONF_THRESHOLD:
             return label
     return None
+
+
+def _pinch_distance(landmarks):
+    """엄지 끝(4) ↔ 검지 끝(8) 거리 (정규화 좌표 기준)."""
+    return _dist3d(landmarks[4], landmarks[8])
+
+
+def _is_pointing(landmarks):
+    """커서 활성: 검지 핀 또는 엄지+검지 핀 (중지·약지·소지 접힘)."""
+    index_ext   = _is_finger_extended(landmarks, 8,  6)
+    others_cls  = (
+        not _is_finger_extended(landmarks, 12, 10) and
+        not _is_finger_extended(landmarks, 16, 14) and
+        not _is_finger_extended(landmarks, 20, 18)
+    )
+    return index_ext and others_cls
 
 
 def _is_open_hand_for_swipe(landmarks):

--- a/asd.txt
+++ b/asd.txt
@@ -1,0 +1,1 @@
+claude --resume c7148bfb-5d23-49b2-b3d6-7dcbde35a2f5

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -36,17 +36,42 @@ export default _isCollect ? CollectTool : function App() {
   const [orderNum,  setOrderNum]  = useState(null)
   const [chatOpen,  setChatOpen]  = useState(false)
 
-  // 제스처 포인터 (손바닥 중심 위치)
-  const [pointer, setPointer] = useState(null)   // { x, y } screen px
-  const pointerRef = useRef(null)                // 최신 포인터 위치 (콜백에서 참조)
+  // 손동작 인식 On/Off & PiP 표시 (localStorage 영구 저장)
+  const [gestureEnabled, setGestureEnabled] = useState(() => {
+    const v = localStorage.getItem('gestureEnabled')
+    return v === null ? true : v === 'true'
+  })
+  const [pipEnabled, setPipEnabled] = useState(() => {
+    return localStorage.getItem('pipEnabled') === 'true'
+  })
+  useEffect(() => { localStorage.setItem('gestureEnabled', String(gestureEnabled)) }, [gestureEnabled])
+  useEffect(() => { localStorage.setItem('pipEnabled',     String(pipEnabled))     }, [pipEnabled])
 
-  // OK 로딩 링 (0.5초 채우면 클릭)
-  const [okPending, setOkPending] = useState(null)  // { x, y } — 링 고정 위치
-  const [okProgress, setOkProgress] = useState(0)  // 0→1
-  const okRafRef = useRef(null)
+  // PiP 캔버스 — useGesture가 매 프레임 카메라 영상 + 관절을 직접 그림
+  const pipCanvasRef = useRef(null)
 
-  // MenuScreen 스와이프 imperative 핸들러
+  // 포인터 — DOM 직접 조작으로 React 리렌더 없이 30fps 업데이트
+  const pointerRef    = useRef(null)   // 최신 위치 { x, y }
+  const pointerDivRef = useRef(null)   // 커서 DOM 노드
+
+  // OK 로딩 링 — DOM 직접 조작
+  const okRingRef = useRef(null)
+  const okRafRef  = useRef(null)
+
+  // 엣지 존 — DOM 직접 조작
+  const EDGE_MARGIN    = 0.10   // 화면 크기의 10%
+  const EDGE_MAX_SPEED = 500    // px/s (최대 강도일 때)
+  const edgeTopRef    = useRef(null)
+  const edgeBottomRef = useRef(null)
+  const edgeLeftRef   = useRef(null)
+  const edgeRightRef  = useRef(null)
+  const edgeStateRef  = useRef({ left: 0, right: 0, top: 0, bottom: 0 })
+  const edgeRafRef    = useRef(null)
+  const edgeLastTRef  = useRef(null)
+
+  // MenuScreen 스와이프 / 모달 imperative 핸들러
   const menuSwipeRef = useRef(null)
+  const menuModalRef = useRef(null)
 
   // 현재 화면을 ref로 유지 — handleGesture 콜백 재생성 없이 참조
   const screenRef = useRef(screen)
@@ -97,68 +122,132 @@ export default _isCollect ? CollectTool : function App() {
     }
   }, [])
 
-  // 포인터: useGesture 의 onPointer 콜백 — 매 MediaPipe 프레임마다 즉시 호출
+  // 엣지 인디케이터 opacity 초기화
+  const clearEdge = useCallback(() => {
+    edgeStateRef.current = { left: 0, right: 0, top: 0, bottom: 0 }
+    if (edgeTopRef.current)    edgeTopRef.current.style.opacity    = 0
+    if (edgeBottomRef.current) edgeBottomRef.current.style.opacity = 0
+    if (edgeLeftRef.current)   edgeLeftRef.current.style.opacity   = 0
+    if (edgeRightRef.current)  edgeRightRef.current.style.opacity  = 0
+  }, [])
+
+  // 포인터: useGesture 의 onPointer 콜백 — React state 없이 DOM 직접 업데이트
   const handlePointer = useCallback((norm) => {
     if (!norm) {
-      setPointer(null)
       pointerRef.current = null
+      // opacity 만 끄기 — DOM은 유지해서 재등장 시 위치가 부드럽게 트랜지션됨
+      if (pointerDivRef.current) pointerDivRef.current.style.opacity = '0'
+      clearEdge()
       return
     }
     const p = normToScreen(norm)
-    setPointer(p)
     pointerRef.current = p
+    const d = pointerDivRef.current
+    if (d) {
+      d.style.left    = `${p.x - 14}px`
+      d.style.top     = `${p.y - 14}px`
+      d.style.opacity = '1'
+    }
+
+    // ── 엣지 존 감지 ──────────────────────────────────────────────────────
+    const nx = p.x / window.innerWidth
+    const ny = p.y / window.innerHeight
+    // 강도: 존 경계에서 0, 화면 끝에서 1
+    const eL = Math.max(0, (EDGE_MARGIN - nx)       / EDGE_MARGIN)
+    const eR = Math.max(0, (EDGE_MARGIN - (1 - nx)) / EDGE_MARGIN)
+    const eT = Math.max(0, (EDGE_MARGIN - ny)       / EDGE_MARGIN)
+    const eB = Math.max(0, (EDGE_MARGIN - (1 - ny)) / EDGE_MARGIN)
+
+    if (edgeTopRef.current)    edgeTopRef.current.style.opacity    = eT
+    if (edgeBottomRef.current) edgeBottomRef.current.style.opacity = eB
+    if (edgeLeftRef.current)   edgeLeftRef.current.style.opacity   = eL
+    if (edgeRightRef.current)  edgeRightRef.current.style.opacity  = eR
+
+    edgeStateRef.current = { left: eL, right: eR, top: eT, bottom: eB }
+
+    // 엣지 자동 스크롤 루프 — 이미 실행 중이면 재시작 안 함
+    if ((eL + eR + eT + eB) > 0 && !edgeRafRef.current) {
+      edgeLastTRef.current = null
+      const tick = (t) => {
+        const cur = pointerRef.current
+        if (!cur) { edgeRafRef.current = null; return }
+        const e = edgeStateRef.current
+        if (e.left + e.right + e.top + e.bottom === 0) { edgeRafRef.current = null; return }
+
+        const dt = edgeLastTRef.current !== null ? (t - edgeLastTRef.current) / 1000 : 0
+        edgeLastTRef.current = t
+
+        if (dt > 0) {
+          const dx = (e.right - e.left) * EDGE_MAX_SPEED * dt
+          const dy = (e.bottom - e.top) * EDGE_MAX_SPEED * dt
+          // 커서 위치 아래의 스크롤 가능한 요소 탐색
+          let el = document.elementFromPoint(cur.x, cur.y)
+          let scrolled = false
+          while (el && el !== document.documentElement) {
+            const cs   = window.getComputedStyle(el)
+            const canY = (cs.overflowY === 'auto' || cs.overflowY === 'scroll') && el.scrollHeight > el.clientHeight
+            const canX = (cs.overflowX === 'auto' || cs.overflowX === 'scroll') && el.scrollWidth  > el.clientWidth
+            if (canY || canX) {
+              if (canY) el.scrollTop  += dy
+              if (canX) el.scrollLeft += dx
+              scrolled = true
+              break
+            }
+            el = el.parentElement
+          }
+          if (!scrolled) window.scrollBy(0, dy)
+        }
+
+        edgeRafRef.current = requestAnimationFrame(tick)
+      }
+      edgeRafRef.current = requestAnimationFrame(tick)
+    }
+
     dispatchActivity()
-  }, [normToScreen, dispatchActivity])
+  }, [normToScreen, dispatchActivity, clearEdge])
 
   // OK 이동 취소 임계값 (screen px) — 이 이상 움직이면 링 취소
   const OK_MOVE_THRESHOLD = 80
 
-  // OK: 손을 충분히 안 움직이면 0.5초 후 클릭
-  // — 이미 진행 중이면 재시작하지 않음 (쿨다운 재발화로 인한 리셋 방지)
-  // — 매 프레임 손 이동 거리 체크, 임계값 초과 or 손 사라지면 취소
+  // OK: 손을 충분히 안 움직이면 0.5초 후 클릭 — DOM 직접 조작으로 rAF 리렌더 없음
   const fireOk = useCallback(() => {
-    if (okRafRef.current !== null) return  // 이미 진행 중
+    if (okRafRef.current !== null) return
 
     const p = pointerRef.current
     if (!p) return
 
-    const startX = p.x
-    const startY = p.y
-    const start  = performance.now()
+    const startX   = p.x
+    const startY   = p.y
+    const start    = performance.now()
     const DURATION = 500
+    const ring     = okRingRef.current
 
-    setOkPending({ x: startX, y: startY })
-    setOkProgress(0)
+    if (ring) {
+      ring.style.display    = 'block'
+      ring.style.left       = `${startX - 28}px`
+      ring.style.top        = `${startY - 28}px`
+      ring.style.background = `conic-gradient(rgba(80,210,255,0.95) 0deg, rgba(255,255,255,0.18) 0deg)`
+    }
 
     const tick = (now) => {
       const cur = pointerRef.current
-
-      // 손 사라짐 or 너무 많이 움직임 → 취소
-      if (!cur) {
+      if (!cur || Math.hypot(cur.x - startX, cur.y - startY) > OK_MOVE_THRESHOLD) {
         okRafRef.current = null
-        setOkPending(null)
-        setOkProgress(0)
-        return
-      }
-      const dist = Math.hypot(cur.x - startX, cur.y - startY)
-      if (dist > OK_MOVE_THRESHOLD) {
-        okRafRef.current = null
-        setOkPending(null)
-        setOkProgress(0)
+        if (ring) ring.style.display = 'none'
         return
       }
 
       const progress = Math.min((now - start) / DURATION, 1)
-      setOkProgress(progress)
+      if (ring) ring.style.background =
+        `conic-gradient(rgba(80,210,255,0.95) ${progress * 360}deg, rgba(255,255,255,0.18) 0deg)`
 
       if (progress < 1) {
         okRafRef.current = requestAnimationFrame(tick)
       } else {
         okRafRef.current = null
+        if (ring) ring.style.display = 'none'
         const el = document.elementFromPoint(startX, startY)
         if (el) el.click()
-        setOkPending(null)
-        setOkProgress(0)
       }
     }
     okRafRef.current = requestAnimationFrame(tick)
@@ -230,9 +319,15 @@ export default _isCollect ? CollectTool : function App() {
       return
     }
 
+    // 메뉴 화면 모달 제스처 (단품/세트 선택) — 스와이프/스크롤보다 먼저 처리
+    if (currentScreen === 'menu' && menuModalRef.current) {
+      if (gesture === 'finger_1') { menuModalRef.current('single'); showLabel('☝ 단품'); return }
+      if (gesture === 'finger_2') { menuModalRef.current('set');    showLabel('✌ 세트');  return }
+    }
+
     // 메뉴 화면 좌우 스와이프 → 페이지/탭 전환
     if (currentScreen === 'menu' && (gesture === 'swipe_left' || gesture === 'swipe_right')) {
-      menuSwipeRef.current?.(gesture === 'swipe_left' ? 'left' : 'right')
+      menuSwipeRef.current?.(gesture === 'swipe_right' ? 'left' : 'right')
       showLabel(GESTURE_LABELS[gesture])
       return
     }
@@ -240,7 +335,24 @@ export default _isCollect ? CollectTool : function App() {
     if (gesture.startsWith('swipe_')) showLabel(GESTURE_LABELS[gesture])
   }, [showLabel, fireOk, scrollAtPointer])
 
-  useGesture({ onPointer: handlePointer, onGesture: handleGesture, enabled: true })
+  useGesture({
+    onPointer:    handlePointer,
+    onGesture:    handleGesture,
+    enabled:      gestureEnabled,
+    pipCanvasRef: gestureEnabled && pipEnabled ? pipCanvasRef : null,
+  })
+
+  // 손동작 OFF: 잔여 포인터/OK 링 UI 즉시 숨김
+  useEffect(() => {
+    if (gestureEnabled) return
+    pointerRef.current = null
+    if (pointerDivRef.current) pointerDivRef.current.style.opacity = '0'
+    if (okRingRef.current)     okRingRef.current.style.display     = 'none'
+    if (okRafRef.current) { cancelAnimationFrame(okRafRef.current); okRafRef.current = null }
+    if (edgeRafRef.current) { cancelAnimationFrame(edgeRafRef.current); edgeRafRef.current = null }
+    edgeStateRef.current = { left: 0, right: 0, top: 0, bottom: 0 }
+  }, [gestureEnabled])
+
 
   const nav = (s) => setScreen(s)
 
@@ -265,10 +377,16 @@ export default _isCollect ? CollectTool : function App() {
   const total = cart.reduce((sum, c) => sum + c.unitPrice * c.qty, 0)
   const props = { cart, total, addToCart, updateQty, clearCart, nav, setOrderNum, orderType, chatOpen }
 
+  const startProps = {
+    ...props,
+    gestureEnabled, setGestureEnabled,
+    pipEnabled,     setPipEnabled,
+  }
+
   const screens = {
-    start:       <StartScreen {...props} />,
+    start:       <StartScreen {...startProps} />,
     orderType:   <OrderTypeScreen nav={nav} setOrderType={setOrderType} />,
-    menu:        <MenuScreen {...props} swipeRef={menuSwipeRef} />,
+    menu:        <MenuScreen {...props} swipeRef={menuSwipeRef} modalRef={menuModalRef} />,
     cart:        <CartScreen {...props} />,
     payment:     <PaymentScreen {...props} />,
     complete:    <CompletionScreen orderNum={orderNum} nav={nav} />,
@@ -298,49 +416,63 @@ export default _isCollect ? CollectTool : function App() {
           </div>
         )}
 
-        {/* ── 제스처 포인터 ── */}
-        {pointer && (
-          <div style={{
-            position: 'fixed',
-            left: pointer.x - 14,
-            top:  pointer.y - 14,
-            width: 28, height: 28,
-            borderRadius: '50%',
-            background: 'rgba(255, 80, 80, 0.55)',
-            border: '2.5px solid rgba(255,255,255,0.85)',
-            pointerEvents: 'none',
-            zIndex: 9000,
-            transition: 'none',
-          }} />
-        )}
+        {/* ── 제스처 포인터 — DOM 직접 조작, React 리렌더 없음 ── */}
+        <div ref={pointerDivRef} style={{
+          position: 'fixed',
+          left: -100, top: -100,
+          width: 28, height: 28,
+          borderRadius: '50%',
+          background: 'rgba(255, 80, 80, 0.55)',
+          border: '2.5px solid rgba(255,255,255,0.85)',
+          pointerEvents: 'none',
+          zIndex: 9000,
+          opacity: 0,
+          // 등장/사라짐만 트랜지션 (위치는 이미 OneEuro로 스무딩됨)
+          transition: 'opacity 0.18s ease-out',
+          willChange: 'left, top, opacity',
+        }} />
 
-        {/* ── OK 로딩 링 (0.5초) ── */}
-        {okPending && (
+        {/* ── 카메라 PiP — 우측 상단 반투명 미리보기 (실제 인식 영역 + 관절) ── */}
+        {gestureEnabled && pipEnabled && (
           <div style={{
             position: 'fixed',
-            left: okPending.x - 28,
-            top:  okPending.y - 28,
-            width: 56, height: 56,
-            borderRadius: '50%',
-            background: `conic-gradient(
-              rgba(80, 210, 255, 0.95) ${okProgress * 360}deg,
-              rgba(255,255,255,0.18) 0deg
-            )`,
+            top: 16, right: 16,
+            width: 200,
+            borderRadius: 10,
+            overflow: 'hidden',
+            border: '1.5px solid rgba(255,255,255,0.45)',
+            boxShadow: '0 4px 18px rgba(0,0,0,0.45)',
+            opacity: 0.82,
+            background: '#000',
             pointerEvents: 'none',
-            zIndex: 9004,
+            zIndex: 9003,
           }}>
-            {/* 안쪽 구멍 */}
-            <div style={{
-              position: 'absolute',
-              inset: 7,
-              borderRadius: '50%',
-              background: 'rgba(0,0,0,0.55)',
-              display: 'flex', alignItems: 'center', justifyContent: 'center',
-              color: 'rgba(255,255,255,0.9)',
-              fontSize: 14, fontWeight: 700,
-            }}>✓</div>
+            {/* canvas 비율은 카메라 해상도에 따라 자동 — width:100% + height:auto 로 왜곡 없이 */}
+            <canvas
+              ref={pipCanvasRef}
+              style={{ display: 'block', width: '100%', height: 'auto' }}
+            />
           </div>
         )}
+
+        {/* ── OK 로딩 링 — DOM 직접 조작 ── */}
+        <div ref={okRingRef} style={{
+          display: 'none',
+          position: 'fixed',
+          width: 56, height: 56,
+          borderRadius: '50%',
+          pointerEvents: 'none',
+          zIndex: 9004,
+        }}>
+          <div style={{
+            position: 'absolute', inset: 7,
+            borderRadius: '50%',
+            background: 'rgba(0,0,0,0.55)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            color: 'rgba(255,255,255,0.9)',
+            fontSize: 14, fontWeight: 700,
+          }}>✓</div>
+        </div>
 
         {/* ── 제스처 라벨 알림 ── */}
         {gestureLabel && (

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -69,10 +69,10 @@ export default _isCollect ? CollectTool : function App() {
   }, [])
 
   // ── 포인터 민감도 ────────────────────────────────────────────────────────
-  // 1.0 = 손이 프레임 끝까지 가야 커서도 끝. 2.0 = 절반만 움직여도 끝까지.
-  // 카메라가 세로(portrait)면 SENS_X를 올리고, 가로(landscape)면 SENS_Y를 올린다.
-  const POINTER_SENS_X = 1.5
-  const POINTER_SENS_Y = 1.5
+  // 앵커 기반 매핑을 useGesture 에서 처리하므로 1.0 고정.
+  // 이동 범위는 useGesture.js 의 ANCHOR_WINDOW_HALF 로 조절.
+  const POINTER_SENS_X = 1.0
+  const POINTER_SENS_Y = 1.0
 
   // 정규화 좌표(MediaPipe 0~1, 좌우 반전 전) → 화면 픽셀로 변환
   const normToScreen = useCallback(({ x, y }) => {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -45,6 +45,9 @@ export default _isCollect ? CollectTool : function App() {
   const [okProgress, setOkProgress] = useState(0)  // 0→1
   const okRafRef = useRef(null)
 
+  // MenuScreen 스와이프 imperative 핸들러
+  const menuSwipeRef = useRef(null)
+
   // 현재 화면을 ref로 유지 — handleGesture 콜백 재생성 없이 참조
   const screenRef = useRef(screen)
   useEffect(() => { screenRef.current = screen }, [screen])
@@ -180,13 +183,11 @@ export default _isCollect ? CollectTool : function App() {
   const [gestureHud, setGestureHud] = useState(null)
 
   const handleGesture = useCallback(({ gesture, hands, total_fingers }) => {
-    // HUD 업데이트 (포인터는 onPointer 가 처리)
-    const gestureDisplay = gesture ? (GESTURE_LABELS[gesture] ?? gesture) : '-'
+    // HUD 업데이트 (포인터는 onPointer 가 처리, 제스처는 showLabel 이 갱신)
     setGestureHud({
-      left:    hands?.left  ? `${hands.left.finger_count}개`  : '-',
-      right:   hands?.right ? `${hands.right.finger_count}개` : '-',
-      total:   total_fingers ?? 0,
-      gesture: gestureDisplay,
+      left:  hands?.left  ? `${hands.left.finger_count}개`  : '-',
+      right: hands?.right ? `${hands.right.finger_count}개` : '-',
+      total: total_fingers ?? 0,
     })
 
     if (!gesture) return
@@ -229,13 +230,9 @@ export default _isCollect ? CollectTool : function App() {
       return
     }
 
-    // 메뉴 화면 좌우 스와이프 → 페이지 ◄/► 버튼 자동 클릭
+    // 메뉴 화면 좌우 스와이프 → 페이지/탭 전환
     if (currentScreen === 'menu' && (gesture === 'swipe_left' || gesture === 'swipe_right')) {
-      const selector = gesture === 'swipe_left'
-        ? 'button[data-page="next"]'
-        : 'button[data-page="prev"]'
-      const btn = document.querySelector(selector)
-      if (btn) btn.click()
+      menuSwipeRef.current?.(gesture === 'swipe_left' ? 'left' : 'right')
       showLabel(GESTURE_LABELS[gesture])
       return
     }
@@ -271,7 +268,7 @@ export default _isCollect ? CollectTool : function App() {
   const screens = {
     start:       <StartScreen {...props} />,
     orderType:   <OrderTypeScreen nav={nav} setOrderType={setOrderType} />,
-    menu:        <MenuScreen {...props} />,
+    menu:        <MenuScreen {...props} swipeRef={menuSwipeRef} />,
     cart:        <CartScreen {...props} />,
     payment:     <PaymentScreen {...props} />,
     complete:    <CompletionScreen orderNum={orderNum} nav={nav} />,
@@ -295,8 +292,8 @@ export default _isCollect ? CollectTool : function App() {
             <div>왼손 &nbsp;: {gestureHud.left}</div>
             <div>오른손: {gestureHud.right}</div>
             <div>합계 &nbsp;: {gestureHud.total}개</div>
-            <div style={{ color: gestureHud.gesture !== '-' ? '#7fff7f' : '#888' }}>
-              제스처: {gestureHud.gesture}
+            <div style={{ color: gestureLabel ? '#7fff7f' : '#888' }}>
+              제스처: {gestureLabel ?? '-'}
             </div>
           </div>
         )}

--- a/frontend/src/hooks/useGesture.js
+++ b/frontend/src/hooks/useGesture.js
@@ -20,6 +20,79 @@ const POINTER_MIN_CUTOFF = 0.15   // Hz — 정지 시 cutoff (낮을수록 떨�
 const POINTER_BETA       = 50.0   // 빠른 동작 반응성
 const POINTER_D_CUTOFF   = 1.0
 const POINTER_DEADZONE   = 0.0018 // 정규화 좌표 (이하 변화는 무시)
+const POINTER_MIRROR_X   = false  // 좌우 반전 적용 여부
+
+// ── 손가락 펴짐 감지 (백엔드와 동일 마진) ───────────────────────────────────
+const EXTENSION_MARGIN_STRICT = 1.15
+const EXTENSION_MARGIN_THUMB  = 1.05
+
+function _dist2d(a, b) {
+  if (!a || !b) return Number.NaN
+  if (!Number.isFinite(a.x) || !Number.isFinite(a.y) ||
+      !Number.isFinite(b.x) || !Number.isFinite(b.y)) {
+    return Number.NaN
+  }
+  const dx = a.x - b.x, dy = a.y - b.y
+  return Math.sqrt(dx * dx + dy * dy)
+}
+
+function _isValidLandmarks(lm) {
+  if (!lm || lm.length < 21) return false
+  for (let i = 0; i < 21; i++) {
+    const p = lm[i]
+    if (!p || !Number.isFinite(p.x) || !Number.isFinite(p.y)) return false
+  }
+  return true
+}
+
+function _isFingerExtended(lm, tipIdx, pipIdx, margin = EXTENSION_MARGIN_STRICT) {
+  const wrist = lm[0]
+  const dTip = _dist2d(lm[tipIdx], wrist)
+  const dPip = _dist2d(lm[pipIdx], wrist)
+  if (!Number.isFinite(dTip) || !Number.isFinite(dPip)) return false
+  return dTip > dPip * margin
+}
+
+function _isThumbExtended(lm) {
+  const dTip = _dist2d(lm[4], lm[5])
+  const dPip = _dist2d(lm[3], lm[5])
+  if (!Number.isFinite(dTip) || !Number.isFinite(dPip)) return false
+  return dTip > dPip * EXTENSION_MARGIN_THUMB
+}
+
+// 커서 활성 조건 A: 검지만 핀 (엄지 무관)
+function _isPointing(lm) {
+  return (
+    _isFingerExtended(lm, 8,  6)  &&
+    !_isFingerExtended(lm, 12, 10) &&
+    !_isFingerExtended(lm, 16, 14) &&
+    !_isFingerExtended(lm, 20, 18)
+  )
+}
+
+// 커서 활성 조건 B: 엄지+검지 동시에 핀 (핀치 전 준비 자세)
+// _isPointing이 이미 엄지를 무시하지만, 엄지 펴짐 시 손 geometry 변화로
+// 검지 판정이 흔들리는 경우를 명시적으로 보완
+function _isThumbIndexOpen(lm) {
+  return (
+    _isThumbExtended(lm)            &&
+    _isFingerExtended(lm, 8,  6)   &&
+    !_isFingerExtended(lm, 12, 10) &&
+    !_isFingerExtended(lm, 16, 14) &&
+    !_isFingerExtended(lm, 20, 18)
+  )
+}
+
+// 엄지 끝(4) ↔ 검지 끝(8) 거리가 임계값 이하 → 핀치(확인 동작)
+const PINCH_DIST_THRESHOLD = 0.08
+function _isPinching(lm) {
+  const d = _dist2d(lm[4], lm[8])
+  return Number.isFinite(d) && d < PINCH_DIST_THRESHOLD
+}
+
+// 앵커 기반 매핑: 검지를 핀 시점을 중심으로 이 범위(±) 안의 손 움직임을 전체 화면에 매핑
+// 값을 낮출수록 조금만 움직여도 커서가 끝까지 이동
+const ANCHOR_WINDOW_HALF = 0.25
 
 // ── One Euro Filter (Casiez et al. 2012) ────────────────────────────────────
 class OneEuro {
@@ -142,9 +215,15 @@ export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enable
     let lastSent = 0
 
     const pointerStates = { Left: makePointerState(), Right: makePointerState() }
+    const anchors       = { Left: null, Right: null }
+    const wasActive     = { Left: false, Right: false }
+    // 커서 숨김 지연 — 포인팅→핀치 전환 순간의 찰나 gap에 커서가 꺼지지 않도록
+    const CURSOR_HIDE_DELAY_MS = 350
+    const hideTimers    = { Left: null, Right: null }
 
     const handleResults = (results) => {
       if (!active) return
+      clearTimeout(inflightWatchdog)
       inflight = false
 
       const lms    = results.multiHandLandmarks || []
@@ -159,34 +238,115 @@ export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enable
         if (lbl === 'Right' && activeIdx < 0) { activeIdx = i; activeLabel = 'Right' }
       }
 
-      // ── 포인터: 즉시 로컬 계산 + 콜백 ─────────────────────────────────
-      if (activeIdx >= 0) {
-        const lm = lms[activeIdx]
-        const px = (lm[5].x + lm[9].x + lm[13].x + lm[17].x) / 4
-        const py = (lm[5].y + lm[9].y + lm[13].y + lm[17].y) / 4
-        const [sx, sy] = smoothPointer(
-          pointerStates[activeLabel], px, py, performance.now() / 1000
-        )
-        pointerRef.current?.({ x: sx, y: sy })
-      } else {
+      // ── 포인터: 앵커 기반 로컬 매핑 ────────────────────────────────────
+      // 포인터 계산은 독립 블록 — 여기서 실패해도 아래 WS 전송은 반드시 실행됨
+      try {
+        if (activeIdx >= 0 && _isValidLandmarks(lms[activeIdx])) {
+          const lm       = lms[activeIdx]
+          const pointing = _isPointing(lm) || _isThumbIndexOpen(lm)
+          const pinching = !pointing && _isPinching(lm)
+
+          if (pointing || pinching) {
+            // 활성 상태 → 지연 타이머 취소
+            clearTimeout(hideTimers[activeLabel])
+            hideTimers[activeLabel] = null
+
+            const px = (lm[5].x + lm[9].x + lm[13].x + lm[17].x) / 4
+            const py = (lm[5].y + lm[9].y + lm[13].y + lm[17].y) / 4
+
+            if (Number.isFinite(px) && Number.isFinite(py)) {
+              if (pointing) {
+                if (!wasActive[activeLabel]) {
+                  anchors[activeLabel] = { x: px, y: py }
+                }
+                wasActive[activeLabel] = true
+
+                const anchor = anchors[activeLabel]
+                const relX   = (px - anchor.x) / ANCHOR_WINDOW_HALF
+                const relY   = (py - anchor.y) / ANCHOR_WINDOW_HALF
+                const baseX  = POINTER_MIRROR_X ? (1 - anchor.x) : anchor.x
+                const dirX   = POINTER_MIRROR_X ? -1 : 1
+                const normX  = Math.max(0, Math.min(1, baseX + relX * 0.5 * dirX))
+                const normY  = Math.max(0, Math.min(1, anchor.y + relY * 0.5))
+                const [sx, sy] = smoothPointer(
+                  pointerStates[activeLabel], normX, normY, performance.now() / 1000
+                )
+                pointerRef.current?.({ x: sx, y: sy })
+              } else {
+                // 핀치(확인 동작): 포인팅과 동일하게 커서 이동
+                if (!wasActive[activeLabel]) {
+                  anchors[activeLabel] = { x: px, y: py }
+                }
+                wasActive[activeLabel] = true
+
+                const anchor = anchors[activeLabel]
+                const relX   = (px - anchor.x) / ANCHOR_WINDOW_HALF
+                const relY   = (py - anchor.y) / ANCHOR_WINDOW_HALF
+                const baseX  = POINTER_MIRROR_X ? (1 - anchor.x) : anchor.x
+                const dirX   = POINTER_MIRROR_X ? -1 : 1
+                const normX  = Math.max(0, Math.min(1, baseX + relX * 0.5 * dirX))
+                const normY  = Math.max(0, Math.min(1, anchor.y + relY * 0.5))
+                const [sx, sy] = smoothPointer(
+                  pointerStates[activeLabel], normX, normY, performance.now() / 1000
+                )
+                pointerRef.current?.({ x: sx, y: sy })
+              }
+            } else {
+              // 좌표 이상 — 즉시 숨김
+              clearTimeout(hideTimers[activeLabel])
+              hideTimers[activeLabel] = null
+              wasActive[activeLabel]  = false
+              anchors[activeLabel]    = null
+              pointerRef.current?.(null)
+            }
+          } else {
+            // 비활성 — CURSOR_HIDE_DELAY_MS 후에 커서 숨김 (전환 gap 보호)
+            if (!hideTimers[activeLabel]) {
+              hideTimers[activeLabel] = setTimeout(() => {
+                hideTimers[activeLabel] = null
+                wasActive[activeLabel]  = false
+                anchors[activeLabel]    = null
+                pointerRef.current?.(null)
+              }, CURSOR_HIDE_DELAY_MS)
+            }
+          }
+        } else {
+          // 손이 사라짐 — 지연 없이 즉시 숨김
+          if (activeLabel) {
+            clearTimeout(hideTimers[activeLabel])
+            hideTimers[activeLabel] = null
+          }
+          pointerRef.current?.(null)
+        }
+      } catch (e) {
+        console.warn('[useGesture] 포인터 계산 오류:', e)
         pointerRef.current?.(null)
       }
 
-      // 현재 안 보이는 손은 필터 reset
+      // 현재 안 보이는 손은 필터·앵커·타이머 reset
       const seen = new Set(handed.map(h => h?.label).filter(Boolean))
       for (const lbl of ['Left', 'Right']) {
-        if (!seen.has(lbl)) resetPointerState(pointerStates[lbl])
+        if (!seen.has(lbl)) {
+          clearTimeout(hideTimers[lbl])
+          hideTimers[lbl] = null
+          resetPointerState(pointerStates[lbl])
+          anchors[lbl]   = null
+          wasActive[lbl] = false
+        }
       }
 
       // ── 랜드마크 페이로드 생성 ────────────────────────────────────────
       const handsPayload = []
       for (let i = 0; i < lms.length; i++) {
-        const lm   = lms[i]
+        const lm = lms[i]
+        if (!_isValidLandmarks(lm)) continue
+
         const flat = new Array(63)
         for (let j = 0; j < 21; j++) {
-          flat[j*3]     = lm[j].x
-          flat[j*3 + 1] = lm[j].y
-          flat[j*3 + 2] = lm[j].z
+          const p = lm[j]
+          flat[j*3]     = p.x
+          flat[j*3 + 1] = p.y
+          flat[j*3 + 2] = p.z
         }
         handsPayload.push({
           label: handed[i]?.label || 'Right',
@@ -205,7 +365,10 @@ export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enable
       }
     }
 
-    const loop = async () => {
+    // inflight 워치독: hands.send()가 영구 hang하면 3초 후 강제 해제
+    let inflightWatchdog = null
+
+    const loop = () => {          // async 제거 — RAF가 항상 예약되도록
       if (!active) return
       const now = performance.now()
       const ready =
@@ -217,14 +380,33 @@ export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enable
       if (ready) {
         inflight = true
         lastSent = now
-        try {
-          await hands.send({ image: video })
-        } catch (err) {
+        // 워치독: onResults가 3초 내에 호출 안 되면 inflight 강제 해제
+        inflightWatchdog = setTimeout(() => {
+          console.warn('[useGesture] hands.send 타임아웃 — inflight 강제 해제')
+          inflight = false
+        }, 3000)
+        hands.send({ image: video }).catch(err => {
+          clearTimeout(inflightWatchdog)
           inflight = false
           console.warn('[useGesture] hands.send 오류:', err)
-        }
+        })
       }
+      // await 없이 항상 다음 RAF 예약 — hands.send hang에도 루프 생존
       rafId = requestAnimationFrame(loop)
+    }
+
+    // WebSocket — 인식 루프와 독립적으로 관리, 끊기면 재연결
+    let wsReconnectTimer = null
+    const openWs = () => {
+      if (!active) return
+      ws = new WebSocket(WS_URL)
+      ws.onmessage = (e) => {
+        try { gestureRef.current?.(JSON.parse(e.data)) } catch {}
+      }
+      ws.onerror = () => { console.warn('[useGesture] WebSocket 오류') }
+      ws.onclose = () => {
+        if (active) wsReconnectTimer = setTimeout(openWs, 2000)
+      }
     }
 
     const setup = async () => {
@@ -249,13 +431,9 @@ export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enable
         })
         hands.onResults(handleResults)
 
-        ws = new WebSocket(WS_URL)
-        ws.onopen    = () => { loop() }
-        ws.onmessage = (e) => {
-          try { gestureRef.current?.(JSON.parse(e.data)) } catch {}
-        }
-        ws.onerror = () => { console.warn('[useGesture] WebSocket 오류') }
-        ws.onclose = () => {}
+        // 루프는 WS와 독립적으로 즉시 시작
+        loop()
+        openWs()
 
       } catch (err) {
         if (!active) return
@@ -267,6 +445,10 @@ export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enable
 
     return () => {
       active = false
+      clearTimeout(inflightWatchdog)
+      clearTimeout(wsReconnectTimer)
+      clearTimeout(hideTimers.Left)
+      clearTimeout(hideTimers.Right)
       if (rafId) cancelAnimationFrame(rafId)
       ws?.close()
       try { hands?.close?.() } catch {}

--- a/frontend/src/hooks/useGesture.js
+++ b/frontend/src/hooks/useGesture.js
@@ -1,10 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { Hands } from '@mediapipe/hands'
 
-// ── WebSocket ────────────────────────────────────────────────────────────────
-const _proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-const WS_URL = `${_proto}//${window.location.host}/ws/gesture`
-
 // ── 카메라 설정 ──────────────────────────────────────────────────────────────
 const CAM_W   = 640
 const CAM_H   = 480
@@ -15,25 +11,35 @@ const MP_BASE = 'https://cdn.jsdelivr.net/npm/@mediapipe/hands/'
 const CAM_RETRY_COUNT = 4
 const CAM_RETRY_DELAY = 1500
 
-// ── 포인터 스무딩 파라미터 (서버측과 동일 — 둘 다 튜닝 가능) ─────────────────
-const POINTER_MIN_CUTOFF = 0.15   // Hz — 정지 시 cutoff (낮을수록 떨림 ↓)
-const POINTER_BETA       = 50.0   // 빠른 동작 반응성
+// ── 포인터 스무딩 파라미터 ────────────────────────────────────────────────────
+const POINTER_MIN_CUTOFF = 0.15
+const POINTER_BETA       = 50.0
 const POINTER_D_CUTOFF   = 1.0
-const POINTER_DEADZONE   = 0.0018 // 정규화 좌표 (이하 변화는 무시)
-const POINTER_MIRROR_X   = false  // 좌우 반전 적용 여부
+const POINTER_DEADZONE   = 0.0018
+const POINTER_MIRROR_X   = false
 
-// ── 손가락 펴짐 감지 (백엔드와 동일 마진) ───────────────────────────────────
+// ── 손가락 펴짐 감지 ─────────────────────────────────────────────────────────
 const EXTENSION_MARGIN_STRICT = 1.15
 const EXTENSION_MARGIN_THUMB  = 1.05
+const EXTENSION_MARGIN_LOOSE  = 1.05  // 스와이프 open-hand 판정
 
 function _dist2d(a, b) {
   if (!a || !b) return Number.NaN
   if (!Number.isFinite(a.x) || !Number.isFinite(a.y) ||
-      !Number.isFinite(b.x) || !Number.isFinite(b.y)) {
-    return Number.NaN
-  }
+      !Number.isFinite(b.x) || !Number.isFinite(b.y)) return Number.NaN
   const dx = a.x - b.x, dy = a.y - b.y
   return Math.sqrt(dx * dx + dy * dy)
+}
+
+// z(깊이)까지 포함한 3D 거리 — 카메라 평면에서 겹쳐 보이지만 실제론 떨어진 동작 구분용
+function _dist3d(a, b) {
+  if (!a || !b) return Number.NaN
+  if (!Number.isFinite(a.x) || !Number.isFinite(a.y) ||
+      !Number.isFinite(b.x) || !Number.isFinite(b.y)) return Number.NaN
+  const dx = a.x - b.x, dy = a.y - b.y
+  // z는 없을 수도 있으므로 0으로 fallback
+  const dz = (Number.isFinite(a.z) && Number.isFinite(b.z)) ? (a.z - b.z) : 0
+  return Math.sqrt(dx * dx + dy * dy + dz * dz)
 }
 
 function _isValidLandmarks(lm) {
@@ -60,39 +66,175 @@ function _isThumbExtended(lm) {
   return dTip > dPip * EXTENSION_MARGIN_THUMB
 }
 
-// 커서 활성 조건 A: 검지만 핀 (엄지 무관)
+// 커서 활성 A: 검지만 핀 (엄지 무관)
 function _isPointing(lm) {
   return (
-    _isFingerExtended(lm, 8,  6)  &&
+     _isFingerExtended(lm, 8,  6) &&
     !_isFingerExtended(lm, 12, 10) &&
     !_isFingerExtended(lm, 16, 14) &&
     !_isFingerExtended(lm, 20, 18)
   )
 }
 
-// 커서 활성 조건 B: 엄지+검지 동시에 핀 (핀치 전 준비 자세)
-// _isPointing이 이미 엄지를 무시하지만, 엄지 펴짐 시 손 geometry 변화로
-// 검지 판정이 흔들리는 경우를 명시적으로 보완
+// 커서 활성 B: 엄지+검지 동시에 핀 (핀치 전 준비 자세)
 function _isThumbIndexOpen(lm) {
   return (
     _isThumbExtended(lm)            &&
-    _isFingerExtended(lm, 8,  6)   &&
-    !_isFingerExtended(lm, 12, 10) &&
-    !_isFingerExtended(lm, 16, 14) &&
+     _isFingerExtended(lm, 8,  6)   &&
+    !_isFingerExtended(lm, 12, 10)  &&
+    !_isFingerExtended(lm, 16, 14)  &&
     !_isFingerExtended(lm, 20, 18)
   )
 }
 
-// 엄지 끝(4) ↔ 검지 끝(8) 거리가 임계값 이하 → 핀치(확인 동작)
-const PINCH_DIST_THRESHOLD = 0.08
+// 핀치: 엄지 끝(4) ↔ 검지 끝(8) 3D 거리 + 검지 부분 펴짐 확인
+// - 2D(x,y)만 쓰면 손을 옆으로 돌려 노드만 겹쳐도 핀치로 오인식됨
+// - 3D 거리를 쓰면 z(깊이) 차이가 커서 해당 동작이 걸러짐
+// - 주먹도 검지 부분 펴짐 조건으로 추가 차단
+const PINCH_DIST_THRESHOLD = 0.06
 function _isPinching(lm) {
-  const d = _dist2d(lm[4], lm[8])
-  return Number.isFinite(d) && d < PINCH_DIST_THRESHOLD
+  const d = _dist3d(lm[4], lm[8])
+  if (!Number.isFinite(d) || d >= PINCH_DIST_THRESHOLD) return false
+  return _isFingerExtended(lm, 8, 6, 0.8)
 }
 
-// 앵커 기반 매핑: 검지를 핀 시점을 중심으로 이 범위(±) 안의 손 움직임을 전체 화면에 매핑
-// 값을 낮출수록 조금만 움직여도 커서가 끝까지 이동
+// 앵커 기반 매핑 범위 (±이 범위가 전체 화면에 매핑)
 const ANCHOR_WINDOW_HALF = 0.25
+// 엣지 도달 시 앵커 이동 비율 (프레임당, 높을수록 빠르게 따라옴 0.0~1.0)
+const EDGE_FOLLOW_RATE   = 0.15
+
+// ── 클라이언트 사이드 제스처 인식 ────────────────────────────────────────────
+
+function _countFingers(lm) {
+  let n = _isThumbExtended(lm) ? 1 : 0
+  for (const [tip, pip] of [[8,6],[12,10],[16,14],[20,18]])
+    if (_isFingerExtended(lm, tip, pip)) n++
+  return n
+}
+
+function _isOpenForSwipe(lm) {
+  let n = _isThumbExtended(lm) ? 1 : 0
+  for (const [tip, pip] of [[8,6],[12,10],[16,14],[20,18]])
+    if (_isFingerExtended(lm, tip, pip, EXTENSION_MARGIN_LOOSE)) n++
+  return n >= 3
+}
+
+function _classifyStatic(lm) {
+  if (_isPinching(lm)) return 'ok'
+  const t = _isThumbExtended(lm)
+  const i = _isFingerExtended(lm, 8,  6)
+  const m = _isFingerExtended(lm, 12, 10)
+  const r = _isFingerExtended(lm, 16, 14)
+  const p = _isFingerExtended(lm, 20, 18)
+  const n = [t, i, m, r, p].filter(Boolean).length
+  if (n === 1 && i)                return 'finger_1'
+  if (n === 2 && i && m)           return 'finger_2'
+  if (n === 3 && i && m && r)      return 'finger_3'
+  if (n === 4 && i && m && r && p) return 'finger_4'
+  if (n === 5)                     return 'finger_5'
+  return null
+}
+
+// FSM debounce
+const G_CONFIRM     = 3
+const G_CONFIRM_OK  = 4
+const G_COOLDOWN    = 800
+const G_COOLDOWN_OK = 600
+
+function makeGestureState() {
+  return { candidate: null, count: 0, lastFire: -Infinity }
+}
+
+function _confirmStatic(state, gesture) {
+  const now = performance.now()
+  const cooldown = gesture === 'ok' ? G_COOLDOWN_OK : G_COOLDOWN
+  if (now - state.lastFire < cooldown) return null
+  if (gesture !== null && gesture === state.candidate) {
+    state.count++
+  } else {
+    state.candidate = gesture
+    state.count     = gesture ? 1 : 0
+  }
+  const needed = gesture === 'ok' ? G_CONFIRM_OK : G_CONFIRM
+  if (state.count >= needed && gesture !== null) {
+    state.count    = 0
+    state.lastFire = now
+    return gesture
+  }
+  return null
+}
+
+// 스와이프 파라미터
+const SWIPE_COOLDOWN_MS      = 600   // 같은 방향 / 무관 쿨다운
+const SWIPE_COOLDOWN_REVERSE = 1500  // 직전과 반대 방향 쿨다운 (복귀 동작 오인식 방지)
+const SWIPE_WINDOW_MS        = 600
+const SWIPE_MIN_FRAMES   = 5
+
+// 좌우 — x 변위 최소치 / y 최대 허용 오차
+const SWIPE_LR_MIN_X     = 0.12
+const SWIPE_LR_MAX_Y     = 0.07
+// 상하 — y 변위 최소치 / x 최대 허용 오차
+const SWIPE_UD_MIN_Y     = 0.10
+const SWIPE_UD_MAX_X     = 0.07
+// 직선도: 순변위 / 총경로 길이 (1=완전직선, 낮을수록 꺾임)
+const SWIPE_STRAIGHTNESS = 0.55
+// 방향 일관성: 같은 방향 스텝 비율 (흔들림/왕복 제거)
+const SWIPE_CONSISTENCY  = 0.65
+
+const _SWIPE_REVERSE = {
+  swipe_left: 'swipe_right', swipe_right: 'swipe_left',
+  swipe_up:   'swipe_down',  swipe_down:  'swipe_up',
+}
+
+// X는 화면 미러링 반영: 카메라 dx<0 = 사용자 기준 오른쪽 → swipe_right
+function _detectSwipe(buf, lastSwipeT, lastSwipeDir, lm) {
+  if (!_isOpenForSwipe(lm)) return null
+  if (buf.length < SWIPE_MIN_FRAMES) return null
+
+  const dx = buf[buf.length - 1].x - buf[0].x
+  const dy = buf[buf.length - 1].y - buf[0].y
+  const adx = Math.abs(dx), ady = Math.abs(dy)
+  const netDist = Math.sqrt(dx * dx + dy * dy)
+  if (netDist < 0.04) return null
+
+  // ① 방향 후보 판별
+  let candidate = null
+  if (adx >= ady && adx >= SWIPE_LR_MIN_X && ady <= SWIPE_LR_MAX_Y) {
+    let pos = 0, neg = 0
+    for (let i = 1; i < buf.length; i++) {
+      const step = buf[i].x - buf[i-1].x
+      if (step >  0.001) pos++
+      else if (step < -0.001) neg++
+    }
+    const total = pos + neg
+    if (total === 0 || Math.max(pos, neg) / total < SWIPE_CONSISTENCY) return null
+    candidate = dx < 0 ? 'swipe_right' : 'swipe_left'
+  } else if (ady > adx && ady >= SWIPE_UD_MIN_Y && adx <= SWIPE_UD_MAX_X) {
+    candidate = dy < 0 ? 'swipe_up' : 'swipe_down'
+  }
+  if (!candidate) return null
+
+  // ② 방향별 쿨다운: 직전과 반대 방향은 더 길게 (복귀 동작 오인식 방지)
+  const isReverse = lastSwipeDir && _SWIPE_REVERSE[lastSwipeDir] === candidate
+  const cooldown  = isReverse ? SWIPE_COOLDOWN_REVERSE : SWIPE_COOLDOWN_MS
+  if (performance.now() - lastSwipeT < cooldown) return null
+
+  // ③ 직선도 체크
+  let pathLen = 0
+  for (let i = 1; i < buf.length; i++) {
+    const px = buf[i].x - buf[i-1].x, py = buf[i].y - buf[i-1].y
+    pathLen += Math.sqrt(px * px + py * py)
+  }
+  if (netDist / (pathLen + 1e-6) < SWIPE_STRAIGHTNESS) return null
+
+  return candidate
+}
+
+const _GESTURE_PRIORITY = {
+  ok: 3,
+  swipe_left: 2, swipe_right: 2, swipe_up: 2, swipe_down: 2,
+  finger_1: 1, finger_2: 1, finger_3: 1, finger_4: 1, finger_5: 1,
+}
 
 // ── One Euro Filter (Casiez et al. 2012) ────────────────────────────────────
 class OneEuro {
@@ -104,27 +246,19 @@ class OneEuro {
     this.dxPrev = 0
     this.tPrev  = null
   }
-  reset() {
-    this.xPrev  = null
-    this.dxPrev = 0
-    this.tPrev  = null
-  }
+  reset() { this.xPrev = null; this.dxPrev = 0; this.tPrev = null }
   filter(x, t) {
-    if (this.xPrev === null) {
-      this.xPrev = x
-      this.tPrev = t
-      return x
-    }
-    const dt = Math.max(t - this.tPrev, 1e-6)
-    const dx = (x - this.xPrev) / dt
-    const aD = lpfAlpha(this.dCutoff, dt)
-    const dxHat = aD * dx + (1 - aD) * this.dxPrev
+    if (this.xPrev === null) { this.xPrev = x; this.tPrev = t; return x }
+    const dt     = Math.max(t - this.tPrev, 1e-6)
+    const dx     = (x - this.xPrev) / dt
+    const aD     = lpfAlpha(this.dCutoff, dt)
+    const dxHat  = aD * dx + (1 - aD) * this.dxPrev
     const cutoff = this.minCutoff + this.beta * Math.abs(dxHat)
-    const a = lpfAlpha(cutoff, dt)
-    const xHat = a * x + (1 - a) * this.xPrev
-    this.xPrev  = xHat
-    this.dxPrev = dxHat
-    this.tPrev  = t
+    const a      = lpfAlpha(cutoff, dt)
+    const xHat   = a * x + (1 - a) * this.xPrev
+    this.xPrev   = xHat
+    this.dxPrev  = dxHat
+    this.tPrev   = t
     return xHat
   }
 }
@@ -146,13 +280,10 @@ function makePointerState() {
 function smoothPointer(state, x, y, t) {
   const nx = state.fx.filter(x, t)
   const ny = state.fy.filter(y, t)
-  if (state.outX === null) {
-    state.outX = nx; state.outY = ny
-    return [nx, ny]
-  }
+  if (state.outX === null) { state.outX = nx; state.outY = ny; return [nx, ny] }
   if (Math.abs(nx - state.outX) < POINTER_DEADZONE &&
       Math.abs(ny - state.outY) < POINTER_DEADZONE) {
-    return [state.outX, state.outY]   // 데드존: 시각적 완전 정지
+    return [state.outX, state.outY]
   }
   state.outX = nx; state.outY = ny
   return [nx, ny]
@@ -168,11 +299,7 @@ async function openCamera() {
   for (let attempt = 1; attempt <= CAM_RETRY_COUNT; attempt++) {
     try {
       return await navigator.mediaDevices.getUserMedia({
-        video: {
-          width:     { ideal: CAM_W },
-          height:    { ideal: CAM_H },
-          frameRate: { ideal: 30 },
-        },
+        video: { width: { ideal: CAM_W }, height: { ideal: CAM_H }, frameRate: { ideal: 30 } },
       })
     } catch (err) {
       const retryable = err.name === 'NotReadableError' || err.name === 'AbortError'
@@ -184,15 +311,11 @@ async function openCamera() {
 }
 
 /**
- * 온디바이스 MediaPipe Hands.
+ * 온디바이스 MediaPipe Hands — 모든 제스처 인식을 클라이언트에서 처리.
  *
- * @param {Object} opts
- * @param {(pos: {x:number, y:number}|null) => void} opts.onPointer
- *        포인터(정규화 0~1) 콜백. 매 MediaPipe 프레임마다 호출 — 네트워크 대기 없음.
- *        손이 사라지면 null 호출.
- * @param {(data: Object) => void} opts.onGesture
- *        서버 응답 콜백. 제스처/손가락 수 등.
- * @param {boolean} opts.enabled
+ * @param {(pos: {x,y}|null) => void} opts.onPointer  정규화 커서 위치 (매 프레임)
+ * @param {(data: Object)    => void} opts.onGesture  제스처 결과 (매 프레임)
+ * @param {(payload: Array)  => void} opts.onLandmarks 원시 랜드마크 (수집 도구용)
  */
 export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enabled = true }) {
   const pointerRef   = useRef(onPointer)
@@ -205,7 +328,6 @@ export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enable
   useEffect(() => {
     if (!enabled) return
 
-    let ws       = null
     let stream   = null
     let video    = null
     let hands    = null
@@ -214,12 +336,18 @@ export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enable
     let inflight = false
     let lastSent = 0
 
+    // ── 포인터 상태 ──────────────────────────────────────────────────────────
     const pointerStates = { Left: makePointerState(), Right: makePointerState() }
     const anchors       = { Left: null, Right: null }
     const wasActive     = { Left: false, Right: false }
-    // 커서 숨김 지연 — 포인팅→핀치 전환 순간의 찰나 gap에 커서가 꺼지지 않도록
     const CURSOR_HIDE_DELAY_MS = 350
     const hideTimers    = { Left: null, Right: null }
+
+    // ── 제스처 상태 ──────────────────────────────────────────────────────────
+    const gestureStates = { Left: makeGestureState(), Right: makeGestureState() }
+    const palmBufs      = { Left: [], Right: [] }
+    const lastSwipes    = { Left: -Infinity, Right: -Infinity }
+    const lastSwipeDirs = { Left: null, Right: null }
 
     const handleResults = (results) => {
       if (!active) return
@@ -230,16 +358,15 @@ export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enable
       const handed = results.multiHandedness     || []
 
       // 사용자의 오른손(MediaPipe "Left") 우선
-      let activeIdx = -1
+      let activeIdx   = -1
       let activeLabel = null
       for (let i = 0; i < handed.length; i++) {
         const lbl = handed[i]?.label
-        if (lbl === 'Left') { activeIdx = i; activeLabel = 'Left'; break }
+        if (lbl === 'Left')  { activeIdx = i; activeLabel = 'Left';  break }
         if (lbl === 'Right' && activeIdx < 0) { activeIdx = i; activeLabel = 'Right' }
       }
 
-      // ── 포인터: 앵커 기반 로컬 매핑 ────────────────────────────────────
-      // 포인터 계산은 독립 블록 — 여기서 실패해도 아래 WS 전송은 반드시 실행됨
+      // ── 포인터 ────────────────────────────────────────────────────────────
       try {
         if (activeIdx >= 0 && _isValidLandmarks(lms[activeIdx])) {
           const lm       = lms[activeIdx]
@@ -247,7 +374,6 @@ export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enable
           const pinching = !pointing && _isPinching(lm)
 
           if (pointing || pinching) {
-            // 활성 상태 → 지연 타이머 취소
             clearTimeout(hideTimers[activeLabel])
             hideTimers[activeLabel] = null
 
@@ -255,44 +381,29 @@ export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enable
             const py = (lm[5].y + lm[9].y + lm[13].y + lm[17].y) / 4
 
             if (Number.isFinite(px) && Number.isFinite(py)) {
-              if (pointing) {
-                if (!wasActive[activeLabel]) {
-                  anchors[activeLabel] = { x: px, y: py }
-                }
-                wasActive[activeLabel] = true
+              if (!wasActive[activeLabel]) anchors[activeLabel] = { x: px, y: py }
+              wasActive[activeLabel] = true
 
-                const anchor = anchors[activeLabel]
-                const relX   = (px - anchor.x) / ANCHOR_WINDOW_HALF
-                const relY   = (py - anchor.y) / ANCHOR_WINDOW_HALF
-                const baseX  = POINTER_MIRROR_X ? (1 - anchor.x) : anchor.x
-                const dirX   = POINTER_MIRROR_X ? -1 : 1
-                const normX  = Math.max(0, Math.min(1, baseX + relX * 0.5 * dirX))
-                const normY  = Math.max(0, Math.min(1, anchor.y + relY * 0.5))
-                const [sx, sy] = smoothPointer(
-                  pointerStates[activeLabel], normX, normY, performance.now() / 1000
-                )
-                pointerRef.current?.({ x: sx, y: sy })
-              } else {
-                // 핀치(확인 동작): 포인팅과 동일하게 커서 이동
-                if (!wasActive[activeLabel]) {
-                  anchors[activeLabel] = { x: px, y: py }
-                }
-                wasActive[activeLabel] = true
-
-                const anchor = anchors[activeLabel]
-                const relX   = (px - anchor.x) / ANCHOR_WINDOW_HALF
-                const relY   = (py - anchor.y) / ANCHOR_WINDOW_HALF
-                const baseX  = POINTER_MIRROR_X ? (1 - anchor.x) : anchor.x
-                const dirX   = POINTER_MIRROR_X ? -1 : 1
-                const normX  = Math.max(0, Math.min(1, baseX + relX * 0.5 * dirX))
-                const normY  = Math.max(0, Math.min(1, anchor.y + relY * 0.5))
-                const [sx, sy] = smoothPointer(
-                  pointerStates[activeLabel], normX, normY, performance.now() / 1000
-                )
-                pointerRef.current?.({ x: sx, y: sy })
-              }
+              const anchor   = anchors[activeLabel]
+              const relX     = (px - anchor.x) / ANCHOR_WINDOW_HALF
+              const relY     = (py - anchor.y) / ANCHOR_WINDOW_HALF
+              const baseX    = POINTER_MIRROR_X ? (1 - anchor.x) : anchor.x
+              const dirX     = POINTER_MIRROR_X ? -1 : 1
+              const rawNormX = baseX + relX * 0.5 * dirX
+              const rawNormY = anchor.y + relY * 0.5
+              // 커서가 화면 끝을 벗어나면 앵커를 손 방향으로 조금씩 이동
+              // → 클러칭 없이 화면 끝 너머로 계속 이동 가능
+              if (rawNormX > 1 || rawNormX < 0)
+                anchor.x += (px - anchor.x) * EDGE_FOLLOW_RATE
+              if (rawNormY > 1 || rawNormY < 0)
+                anchor.y += (py - anchor.y) * EDGE_FOLLOW_RATE
+              const normX  = Math.max(0, Math.min(1, rawNormX))
+              const normY  = Math.max(0, Math.min(1, rawNormY))
+              const [sx, sy] = smoothPointer(
+                pointerStates[activeLabel], normX, normY, performance.now() / 1000
+              )
+              pointerRef.current?.({ x: sx, y: sy })
             } else {
-              // 좌표 이상 — 즉시 숨김
               clearTimeout(hideTimers[activeLabel])
               hideTimers[activeLabel] = null
               wasActive[activeLabel]  = false
@@ -300,7 +411,6 @@ export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enable
               pointerRef.current?.(null)
             }
           } else {
-            // 비활성 — CURSOR_HIDE_DELAY_MS 후에 커서 숨김 (전환 gap 보호)
             if (!hideTimers[activeLabel]) {
               hideTimers[activeLabel] = setTimeout(() => {
                 hideTimers[activeLabel] = null
@@ -311,11 +421,7 @@ export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enable
             }
           }
         } else {
-          // 손이 사라짐 — 지연 없이 즉시 숨김
-          if (activeLabel) {
-            clearTimeout(hideTimers[activeLabel])
-            hideTimers[activeLabel] = null
-          }
+          if (activeLabel) { clearTimeout(hideTimers[activeLabel]); hideTimers[activeLabel] = null }
           pointerRef.current?.(null)
         }
       } catch (e) {
@@ -323,64 +429,97 @@ export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enable
         pointerRef.current?.(null)
       }
 
-      // 현재 안 보이는 손은 필터·앵커·타이머 reset
+      // 안 보이는 손 리셋
       const seen = new Set(handed.map(h => h?.label).filter(Boolean))
       for (const lbl of ['Left', 'Right']) {
         if (!seen.has(lbl)) {
           clearTimeout(hideTimers[lbl])
-          hideTimers[lbl] = null
+          hideTimers[lbl]       = null
           resetPointerState(pointerStates[lbl])
-          anchors[lbl]   = null
-          wasActive[lbl] = false
+          anchors[lbl]          = null
+          wasActive[lbl]        = false
+          gestureStates[lbl]    = makeGestureState()
+          palmBufs[lbl].length  = 0
+          lastSwipeDirs[lbl]    = null
         }
       }
 
-      // ── 랜드마크 페이로드 생성 ────────────────────────────────────────
+      // ── 랜드마크 페이로드 (수집 도구용) ───────────────────────────────────
       const handsPayload = []
       for (let i = 0; i < lms.length; i++) {
         const lm = lms[i]
         if (!_isValidLandmarks(lm)) continue
-
         const flat = new Array(63)
         for (let j = 0; j < 21; j++) {
-          const p = lm[j]
-          flat[j*3]     = p.x
-          flat[j*3 + 1] = p.y
-          flat[j*3 + 2] = p.z
+          flat[j*3] = lm[j].x; flat[j*3+1] = lm[j].y; flat[j*3+2] = lm[j].z
         }
-        handsPayload.push({
-          label: handed[i]?.label || 'Right',
-          lm:    flat,
-        })
+        handsPayload.push({ label: handed[i]?.label || 'Right', lm: flat })
+      }
+      landmarksRef.current?.(handsPayload)
+
+      // ── 제스처 인식 (클라이언트 전담) ────────────────────────────────────
+      const handData = {}
+      const frameNow = performance.now()
+
+      for (let i = 0; i < lms.length; i++) {
+        const lm = lms[i]
+        if (!_isValidLandmarks(lm)) continue
+        const mpLabel = handed[i]?.label || 'Right'
+        const side    = mpLabel === 'Left' ? 'right' : 'left'
+
+        // 원시 손바닥 중심 — 앵커 변환 없이 절대 위치 (스와이프 추적용)
+        const rpx = (lm[5].x + lm[9].x + lm[13].x + lm[17].x) / 4
+        const rpy = (lm[5].y + lm[9].y + lm[13].y + lm[17].y) / 4
+        palmBufs[mpLabel].push({ x: rpx, y: rpy, t: frameNow })
+        const cutoff = frameNow - SWIPE_WINDOW_MS
+        while (palmBufs[mpLabel].length && palmBufs[mpLabel][0].t < cutoff)
+          palmBufs[mpLabel].shift()
+
+        let gesture = null
+        const swipe = _detectSwipe(palmBufs[mpLabel], lastSwipes[mpLabel], lastSwipeDirs[mpLabel], lm)
+        if (swipe) {
+          lastSwipes[mpLabel]              = frameNow
+          lastSwipeDirs[mpLabel]           = swipe
+          palmBufs[mpLabel].length         = 0
+          gestureStates[mpLabel].candidate = null
+          gestureStates[mpLabel].count     = 0
+          gesture = swipe
+        } else {
+          gesture = _confirmStatic(gestureStates[mpLabel], _classifyStatic(lm))
+        }
+
+        handData[side] = {
+          gesture,
+          finger_count:   _countFingers(lm),
+          pinch_distance: +_dist3d(lm[4], lm[8]).toFixed(4),
+          is_pointing:    _isPointing(lm) || _isThumbIndexOpen(lm),
+        }
       }
 
-      // onLandmarks: 수집 도구용 (매 프레임 원시 랜드마크 전달)
-      if (landmarksRef.current) {
-        landmarksRef.current(handsPayload)
-      }
+      const fired    = Object.values(handData).map(d => d.gesture).filter(Boolean)
+      const dominant = fired.length
+        ? fired.reduce((a, b) =>
+            (_GESTURE_PRIORITY[a] ?? 0) >= (_GESTURE_PRIORITY[b] ?? 0) ? a : b)
+        : null
 
-      // ── 서버로 랜드마크 전송 (제스처 분류용) ─────────────────────────
-      if (ws?.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify({ hands: handsPayload }))
-      }
+      gestureRef.current?.({
+        hands:         { left: handData.left ?? null, right: handData.right ?? null },
+        total_fingers: Object.values(handData).reduce((s, d) => s + d.finger_count, 0),
+        gesture:       dominant,
+      })
     }
 
-    // inflight 워치독: hands.send()가 영구 hang하면 3초 후 강제 해제
+    // inflight 워치독
     let inflightWatchdog = null
 
-    const loop = () => {          // async 제거 — RAF가 항상 예약되도록
+    const loop = () => {
       if (!active) return
-      const now = performance.now()
-      const ready =
-        !inflight &&
-        video && video.readyState >= 2 &&
-        hands &&
-        now - lastSent >= 1000 / MAX_FPS
-
+      const now   = performance.now()
+      const ready = !inflight && video && video.readyState >= 2 && hands &&
+                    now - lastSent >= 1000 / MAX_FPS
       if (ready) {
         inflight = true
         lastSent = now
-        // 워치독: onResults가 3초 내에 호출 안 되면 inflight 강제 해제
         inflightWatchdog = setTimeout(() => {
           console.warn('[useGesture] hands.send 타임아웃 — inflight 강제 해제')
           inflight = false
@@ -391,22 +530,7 @@ export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enable
           console.warn('[useGesture] hands.send 오류:', err)
         })
       }
-      // await 없이 항상 다음 RAF 예약 — hands.send hang에도 루프 생존
       rafId = requestAnimationFrame(loop)
-    }
-
-    // WebSocket — 인식 루프와 독립적으로 관리, 끊기면 재연결
-    let wsReconnectTimer = null
-    const openWs = () => {
-      if (!active) return
-      ws = new WebSocket(WS_URL)
-      ws.onmessage = (e) => {
-        try { gestureRef.current?.(JSON.parse(e.data)) } catch {}
-      }
-      ws.onerror = () => { console.warn('[useGesture] WebSocket 오류') }
-      ws.onclose = () => {
-        if (active) wsReconnectTimer = setTimeout(openWs, 2000)
-      }
     }
 
     const setup = async () => {
@@ -430,10 +554,7 @@ export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enable
           minTrackingConfidence:  0.5,
         })
         hands.onResults(handleResults)
-
-        // 루프는 WS와 독립적으로 즉시 시작
         loop()
-        openWs()
 
       } catch (err) {
         if (!active) return
@@ -446,11 +567,9 @@ export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enable
     return () => {
       active = false
       clearTimeout(inflightWatchdog)
-      clearTimeout(wsReconnectTimer)
       clearTimeout(hideTimers.Left)
       clearTimeout(hideTimers.Right)
       if (rafId) cancelAnimationFrame(rafId)
-      ws?.close()
       try { hands?.close?.() } catch {}
       stream?.getTracks().forEach(t => t.stop())
       if (videoRef) videoRef.current = null

--- a/frontend/src/hooks/useGesture.js
+++ b/frontend/src/hooks/useGesture.js
@@ -4,7 +4,9 @@ import { Hands } from '@mediapipe/hands'
 // ── 카메라 설정 ──────────────────────────────────────────────────────────────
 const CAM_W   = 640
 const CAM_H   = 480
-const MAX_FPS = 30
+const MAX_FPS = 20
+// 임계값 튜닝 기준 비율 (4:3). 실제 카메라 비율이 다르면 자동 보정됨.
+const AR_REF  = CAM_W / CAM_H   // ≈ 1.333
 
 const MP_BASE = 'https://cdn.jsdelivr.net/npm/@mediapipe/hands/'
 
@@ -22,6 +24,11 @@ const POINTER_MIRROR_X   = false
 const EXTENSION_MARGIN_STRICT = 1.15
 const EXTENSION_MARGIN_THUMB  = 1.05
 const EXTENSION_MARGIN_LOOSE  = 1.05  // 스와이프 open-hand 판정
+// 가리키는 동작용 — 자연스럽게 살짝 굽은 검지도 인식
+const EXTENSION_MARGIN_POINT       = 1.08
+// 히스테리시스: 이미 가리키는 중이면 더 관대 (잠깐 굽혀도 유지)
+const EXTENSION_MARGIN_POINT_HOLD  = 1.00
+const EXTENSION_MARGIN_FOLD_HOLD   = 1.18  // 다른 손가락 "안 펴짐" 판정도 완화
 
 function _dist2d(a, b) {
   if (!a || !b) return Number.NaN
@@ -51,6 +58,15 @@ function _isValidLandmarks(lm) {
   return true
 }
 
+// 손목(0) → 중지 MCP(9) 거리 — 멀수록 작아지는 손 크기 지표
+// 카메라 비율에 무관하게 비교하려면 x를 보정해야 하지만,
+// 여기선 단순 임계값 비교이므로 2D 그대로 사용
+const MIN_PALM_SIZE = 0.10  // 이 이하면 너무 멀리 있는 손으로 간주
+
+function _palmSize(lm) {
+  return _dist2d(lm[0], lm[9])
+}
+
 function _isFingerExtended(lm, tipIdx, pipIdx, margin = EXTENSION_MARGIN_STRICT) {
   const wrist = lm[0]
   const dTip = _dist2d(lm[tipIdx], wrist)
@@ -69,7 +85,7 @@ function _isThumbExtended(lm) {
 // 커서 활성 A: 검지만 핀 (엄지 무관)
 function _isPointing(lm) {
   return (
-     _isFingerExtended(lm, 8,  6) &&
+     _isFingerExtended(lm, 8,  6, EXTENSION_MARGIN_POINT) &&
     !_isFingerExtended(lm, 12, 10) &&
     !_isFingerExtended(lm, 16, 14) &&
     !_isFingerExtended(lm, 20, 18)
@@ -79,29 +95,51 @@ function _isPointing(lm) {
 // 커서 활성 B: 엄지+검지 동시에 핀 (핀치 전 준비 자세)
 function _isThumbIndexOpen(lm) {
   return (
-    _isThumbExtended(lm)            &&
-     _isFingerExtended(lm, 8,  6)   &&
-    !_isFingerExtended(lm, 12, 10)  &&
-    !_isFingerExtended(lm, 16, 14)  &&
+    _isThumbExtended(lm)                                  &&
+     _isFingerExtended(lm, 8,  6, EXTENSION_MARGIN_POINT) &&
+    !_isFingerExtended(lm, 12, 10)                        &&
+    !_isFingerExtended(lm, 16, 14)                        &&
     !_isFingerExtended(lm, 20, 18)
   )
 }
 
-// 핀치: 엄지 끝(4) ↔ 검지 끝(8) 3D 거리 + 검지 부분 펴짐 확인
-// - 2D(x,y)만 쓰면 손을 옆으로 돌려 노드만 겹쳐도 핀치로 오인식됨
-// - 3D 거리를 쓰면 z(깊이) 차이가 커서 해당 동작이 걸러짐
-// - 주먹도 검지 부분 펴짐 조건으로 추가 차단
-const PINCH_DIST_THRESHOLD = 0.06
-function _isPinching(lm) {
-  const d = _dist3d(lm[4], lm[8])
-  if (!Number.isFinite(d) || d >= PINCH_DIST_THRESHOLD) return false
+// 히스테리시스: 이미 가리키는 중일 때 검사 — 검지는 더 관대하게, 나머지는 살짝 펴져도 허용
+// (잠깐 손가락이 굽거나 떨려도 커서가 끊기지 않게 함)
+function _isPointingHold(lm) {
+  const indexOK = _isFingerExtended(lm, 8, 6, EXTENSION_MARGIN_POINT_HOLD)
+  const otherFolded =
+    !_isFingerExtended(lm, 12, 10, EXTENSION_MARGIN_FOLD_HOLD) &&
+    !_isFingerExtended(lm, 16, 14, EXTENSION_MARGIN_FOLD_HOLD) &&
+    !_isFingerExtended(lm, 20, 18, EXTENSION_MARGIN_FOLD_HOLD)
+  return indexOK && otherFolded
+}
+
+// 핀치: 엄지(4) ↔ 검지(8) 거리를 손 크기(팜 사이즈) 대비 비율로 판정
+// - 3D z 기반 고정 임계값은 카메라 각도에 따라 z 추정이 불안정해 오탈락이 많음
+// - 팜 크기 정규화 비율은 손이 멀거나 가깝거나, 각도가 달라도 일관된 값 유지
+// - 히스테리시스: 진입 임계(더 엄격) vs 유지 임계(더 관대) → 각도 변화에서 끊김 방지
+// - 주먹 오인식 차단은 _isFingerExtended(8, 6, 0.8) 유지 (검지가 조금이라도 펴져야 함)
+const PINCH_RATIO_ENTER = 0.30   // 팜 대비 30% 이내: 핀치 진입
+const PINCH_RATIO_EXIT  = 0.44   // 팜 대비 44% 이내: 핀치 유지 (히스테리시스)
+
+function _isPinching(lm, alreadyPinching = false) {
+  const palm = _palmSize(lm)
+  if (!Number.isFinite(palm) || palm < 1e-6) return false
+  const d     = _dist2d(lm[4], lm[8])
+  if (!Number.isFinite(d)) return false
+  const ratio = d / palm
+  const thr   = alreadyPinching ? PINCH_RATIO_EXIT : PINCH_RATIO_ENTER
+  if (ratio >= thr) return false
   return _isFingerExtended(lm, 8, 6, 0.8)
 }
 
-// 앵커 기반 매핑 범위 (±이 범위가 전체 화면에 매핑)
-const ANCHOR_WINDOW_HALF = 0.25
-// 엣지 도달 시 앵커 이동 비율 (프레임당, 높을수록 빠르게 따라옴 0.0~1.0)
-const EDGE_FOLLOW_RATE   = 0.15
+// 카메라 활성 구역 마진 (손바닥 중심 기준 → 손가락 끝 오프셋 보정 포함)
+const CAM_MARGIN_L   = 0.20   // 좌: 손 측면 오프셋 보정
+const CAM_MARGIN_R   = 0.20   // 우: 손 측면 오프셋 보정
+const CAM_MARGIN_TOP = 0.25   // 상: 기본 10% + 손가락 끝↔손바닥 중심 차이 15%
+const CAM_MARGIN_BOT = 0.10
+const CAM_ACTIVE_X   = 1.0 - CAM_MARGIN_L - CAM_MARGIN_R     // 0.60
+const CAM_ACTIVE_Y   = 1.0 - CAM_MARGIN_TOP - CAM_MARGIN_BOT // 0.65
 
 // ── 클라이언트 사이드 제스처 인식 ────────────────────────────────────────────
 
@@ -119,8 +157,8 @@ function _isOpenForSwipe(lm) {
   return n >= 3
 }
 
-function _classifyStatic(lm) {
-  if (_isPinching(lm)) return 'ok'
+// 핀치 제외 정적 분류 — 루프에서 핀치를 별도 체크한 뒤 나머지 분류에 사용
+function _classifyStaticNoPinch(lm) {
   const t = _isThumbExtended(lm)
   const i = _isFingerExtended(lm, 8,  6)
   const m = _isFingerExtended(lm, 12, 10)
@@ -133,6 +171,11 @@ function _classifyStatic(lm) {
   if (n === 4 && i && m && r && p) return 'finger_4'
   if (n === 5)                     return 'finger_5'
   return null
+}
+
+function _classifyStatic(lm) {
+  if (_isPinching(lm)) return 'ok'
+  return _classifyStaticNoPinch(lm)
 }
 
 // FSM debounce
@@ -166,63 +209,99 @@ function _confirmStatic(state, gesture) {
 
 // 스와이프 파라미터
 const SWIPE_COOLDOWN_MS      = 600   // 같은 방향 / 무관 쿨다운
-const SWIPE_COOLDOWN_REVERSE = 1500  // 직전과 반대 방향 쿨다운 (복귀 동작 오인식 방지)
-const SWIPE_WINDOW_MS        = 600
-const SWIPE_MIN_FRAMES   = 5
+const SWIPE_COOLDOWN_REVERSE = 1500  // 직전 반대 방향 쿨다운 (복귀 동작 오인식 방지)
+const SWIPE_WINDOW_MS        = 700   // 버퍼 유지 시간
+const SWIPE_MIN_FRAMES       = 4     // 트림 후 최소 프레임 수
+const SWIPE_STEP_THRESHOLD   = 0.004 // 프레임 간 이동 최소치 (정지 판정)
 
 // 좌우 — x 변위 최소치 / y 최대 허용 오차
-const SWIPE_LR_MIN_X     = 0.12
-const SWIPE_LR_MAX_Y     = 0.07
+const SWIPE_LR_MIN_X     = 0.10
+const SWIPE_LR_MAX_Y     = 0.08
 // 상하 — y 변위 최소치 / x 최대 허용 오차
-const SWIPE_UD_MIN_Y     = 0.10
-const SWIPE_UD_MAX_X     = 0.07
-// 직선도: 순변위 / 총경로 길이 (1=완전직선, 낮을수록 꺾임)
-const SWIPE_STRAIGHTNESS = 0.55
-// 방향 일관성: 같은 방향 스텝 비율 (흔들림/왕복 제거)
+const SWIPE_UD_MIN_Y     = 0.09
+const SWIPE_UD_MAX_X     = 0.08
+// 직선도: 순변위 / 총경로 길이
+const SWIPE_STRAIGHTNESS = 0.50
+// 방향 일관성: 같은 방향 스텝 비율
 const SWIPE_CONSISTENCY  = 0.65
+// 최소 속도: 정규화 단위/초 (느린 드리프트 차단)
+const SWIPE_MIN_SPEED    = 0.25
 
 const _SWIPE_REVERSE = {
   swipe_left: 'swipe_right', swipe_right: 'swipe_left',
   swipe_up:   'swipe_down',  swipe_down:  'swipe_up',
 }
 
-// X는 화면 미러링 반영: 카메라 dx<0 = 사용자 기준 오른쪽 → swipe_right
-function _detectSwipe(buf, lastSwipeT, lastSwipeDir, lm) {
-  if (!_isOpenForSwipe(lm)) return null
-  if (buf.length < SWIPE_MIN_FRAMES) return null
+// 버퍼 앞뒤의 정지 프레임 제거 — 스와이프 전 대기·후 감속 구간이 분석을 희석하는 것을 방지
+function _trimBuf(buf) {
+  let start = 0
+  while (start < buf.length - 2) {
+    const d = Math.hypot(buf[start+1].x - buf[start].x, buf[start+1].y - buf[start].y)
+    if (d >= SWIPE_STEP_THRESHOLD) break
+    start++
+  }
+  let end = buf.length - 1
+  while (end > start + 2) {
+    const d = Math.hypot(buf[end].x - buf[end-1].x, buf[end].y - buf[end-1].y)
+    if (d >= SWIPE_STEP_THRESHOLD) break
+    end--
+  }
+  return start === 0 && end === buf.length - 1 ? buf : buf.slice(start, end + 1)
+}
 
-  const dx = buf[buf.length - 1].x - buf[0].x
-  const dy = buf[buf.length - 1].y - buf[0].y
+// X는 화면 미러링 반영: 카메라 dx<0 = 사용자 기준 오른쪽 → swipe_right
+// camAR: 실제 카메라 비율(width/height). AR_REF 기준으로 x를 물리 단위로 보정.
+function _detectSwipe(buf, lastSwipeT, lastSwipeDir, lm, camAR) {
+  if (!_isOpenForSwipe(lm)) return null
+
+  // 정지 구간 제거 후 분석
+  const a = _trimBuf(buf)
+  if (a.length < SWIPE_MIN_FRAMES) return null
+
+  // 정규화 x를 물리 단위로 변환 — 카메라 비율이 달라도 임계값이 일정한 물리 거리에 대응
+  // wide(16:9): camAR/AR_REF > 1 → 같은 normalized dx = 더 넓은 물리 이동 → 스케일 업
+  // tall(9:16): camAR/AR_REF < 1 → 같은 normalized dx = 좁은 물리 이동 → 스케일 다운
+  const xPhys = camAR / AR_REF
+
+  const rawDx = a[a.length - 1].x - a[0].x
+  const rawDy = a[a.length - 1].y - a[0].y
+  const dx  = rawDx * xPhys   // 물리 단위 x 변위
+  const dy  = rawDy            // y는 그대로
   const adx = Math.abs(dx), ady = Math.abs(dy)
   const netDist = Math.sqrt(dx * dx + dy * dy)
-  if (netDist < 0.04) return null
 
-  // ① 방향 후보 판별
+  // ① 방향 후보 판별 (물리 단위 기준)
   let candidate = null
   if (adx >= ady && adx >= SWIPE_LR_MIN_X && ady <= SWIPE_LR_MAX_Y) {
+    // 방향 일관성은 부호만 보므로 raw x step 그대로 사용
     let pos = 0, neg = 0
-    for (let i = 1; i < buf.length; i++) {
-      const step = buf[i].x - buf[i-1].x
+    for (let i = 1; i < a.length; i++) {
+      const step = a[i].x - a[i-1].x
       if (step >  0.001) pos++
       else if (step < -0.001) neg++
     }
     const total = pos + neg
     if (total === 0 || Math.max(pos, neg) / total < SWIPE_CONSISTENCY) return null
-    candidate = dx < 0 ? 'swipe_right' : 'swipe_left'
+    candidate = rawDx < 0 ? 'swipe_right' : 'swipe_left'
   } else if (ady > adx && ady >= SWIPE_UD_MIN_Y && adx <= SWIPE_UD_MAX_X) {
-    candidate = dy < 0 ? 'swipe_up' : 'swipe_down'
+    candidate = rawDy < 0 ? 'swipe_up' : 'swipe_down'
   }
   if (!candidate) return null
 
-  // ② 방향별 쿨다운: 직전과 반대 방향은 더 길게 (복귀 동작 오인식 방지)
+  // ② 방향별 쿨다운
   const isReverse = lastSwipeDir && _SWIPE_REVERSE[lastSwipeDir] === candidate
   const cooldown  = isReverse ? SWIPE_COOLDOWN_REVERSE : SWIPE_COOLDOWN_MS
   if (performance.now() - lastSwipeT < cooldown) return null
 
-  // ③ 직선도 체크
+  // ③ 속도 게이트 (물리 단위)
+  const dt = (a[a.length - 1].t - a[0].t) / 1000
+  if (dt < 0.05 || netDist / dt < SWIPE_MIN_SPEED) return null
+
+  // ④ 직선도 (물리 단위)
   let pathLen = 0
-  for (let i = 1; i < buf.length; i++) {
-    const px = buf[i].x - buf[i-1].x, py = buf[i].y - buf[i-1].y
+  for (let i = 1; i < a.length; i++) {
+    const px = (a[i].x - a[i-1].x) * xPhys
+    const py =  a[i].y - a[i-1].y
     pathLen += Math.sqrt(px * px + py * py)
   }
   if (netDist / (pathLen + 1e-6) < SWIPE_STRAIGHTNESS) return null
@@ -294,6 +373,67 @@ function resetPointerState(s) {
   s.outX = null; s.outY = null
 }
 
+// ── MediaPipe 관절 연결선 (21개 랜드마크) ─────────────────────────────────────
+const HAND_CONNECTIONS = [
+  [0,1],[1,2],[2,3],[3,4],           // 엄지
+  [0,5],[5,6],[6,7],[7,8],           // 검지
+  [5,9],[9,10],[10,11],[11,12],      // 중지
+  [9,13],[13,14],[14,15],[15,16],    // 약지
+  [13,17],[17,18],[18,19],[19,20],   // 소지
+  [0,17],[5,9],[9,13],[13,17],       // 손바닥
+]
+
+// PiP 캔버스에 영상 + 랜드마크를 그린다 (미러 반전 포함)
+function _drawPip(canvas, video, lms, handed) {
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return
+  const vw = video.videoWidth, vh = video.videoHeight
+  if (!vw || !vh) return
+  if (canvas.width !== vw || canvas.height !== vh) {
+    canvas.width  = vw
+    canvas.height = vh
+  }
+  // 미러 반전 영상
+  ctx.save()
+  ctx.translate(vw, 0)
+  ctx.scale(-1, 1)
+  ctx.drawImage(video, 0, 0)
+  ctx.restore()
+
+  // 각 손 랜드마크
+  for (let hi = 0; hi < lms.length; hi++) {
+    const lm    = lms[hi]
+    if (!lm || lm.length < 21) continue
+    const isRight = handed[hi]?.label === 'Right'  // MP 기준 (사용자 왼손)
+
+    // 연결선
+    ctx.lineWidth   = 2.5
+    ctx.strokeStyle = isRight ? 'rgba(100,160,255,0.9)' : 'rgba(80,220,130,0.9)'
+    for (const [a, b] of HAND_CONNECTIONS) {
+      ctx.beginPath()
+      ctx.moveTo((1 - lm[a].x) * vw, lm[a].y * vh)
+      ctx.lineTo((1 - lm[b].x) * vw, lm[b].y * vh)
+      ctx.stroke()
+    }
+
+    // 관절 점
+    for (let j = 0; j < 21; j++) {
+      const x = (1 - lm[j].x) * vw
+      const y = lm[j].y * vh
+      const isTip = [4, 8, 12, 16, 20].includes(j)
+      ctx.beginPath()
+      ctx.arc(x, y, isTip ? 5 : 3, 0, Math.PI * 2)
+      ctx.fillStyle   = j === 0 ? 'rgba(255,80,80,0.95)'
+                      : isTip  ? 'rgba(255,230,60,0.95)'
+                                : 'rgba(255,255,255,0.85)'
+      ctx.strokeStyle = 'rgba(0,0,0,0.4)'
+      ctx.lineWidth   = 1
+      ctx.fill()
+      ctx.stroke()
+    }
+  }
+}
+
 // ── 카메라 ───────────────────────────────────────────────────────────────────
 async function openCamera() {
   for (let attempt = 1; attempt <= CAM_RETRY_COUNT; attempt++) {
@@ -317,7 +457,7 @@ async function openCamera() {
  * @param {(data: Object)    => void} opts.onGesture  제스처 결과 (매 프레임)
  * @param {(payload: Array)  => void} opts.onLandmarks 원시 랜드마크 (수집 도구용)
  */
-export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enabled = true }) {
+export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, pipCanvasRef, enabled = true }) {
   const pointerRef   = useRef(onPointer)
   const gestureRef   = useRef(onGesture)
   const landmarksRef = useRef(onLandmarks)
@@ -335,11 +475,13 @@ export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enable
     let active   = true
     let inflight = false
     let lastSent = 0
+    let camAR    = AR_REF   // 카메라 실제 비율 (열린 후 갱신)
 
     // ── 포인터 상태 ──────────────────────────────────────────────────────────
     const pointerStates = { Left: makePointerState(), Right: makePointerState() }
-    const anchors       = { Left: null, Right: null }
     const wasActive     = { Left: false, Right: false }
+    // 한 번 가리키기 시작했으면 잠깐 흔들려도 끊기지 않게 — 히스테리시스
+    const wasPointing   = { Left: false, Right: false }
     const CURSOR_HIDE_DELAY_MS = 350
     const hideTimers    = { Left: null, Right: null }
 
@@ -348,6 +490,10 @@ export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enable
     const palmBufs      = { Left: [], Right: [] }
     const lastSwipes    = { Left: -Infinity, Right: -Infinity }
     const lastSwipeDirs = { Left: null, Right: null }
+    // ok 발화 후 손을 한 번 펴야 다음 ok 허용 (같은 자리 연속 발화 방지)
+    const okNeedsOpen   = { Left: false, Right: false }
+    // 핀치 히스테리시스 — 진입/유지 임계를 구분해 각도 변화에서 끊기지 않게 함
+    const wasPinching   = { Left: false, Right: false }
 
     const handleResults = (results) => {
       if (!active) return
@@ -368,37 +514,43 @@ export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enable
 
       // ── 포인터 ────────────────────────────────────────────────────────────
       try {
-        if (activeIdx >= 0 && _isValidLandmarks(lms[activeIdx])) {
+        if (activeIdx >= 0 && _isValidLandmarks(lms[activeIdx]) &&
+            _palmSize(lms[activeIdx]) >= MIN_PALM_SIZE) {
           const lm       = lms[activeIdx]
-          const pointing = _isPointing(lm) || _isThumbIndexOpen(lm)
-          const pinching = !pointing && _isPinching(lm)
+          // 히스테리시스: 이미 가리키는 중이면 더 관대한 조건으로 유지 → 끊김 감소
+          const pointing = wasPointing[activeLabel]
+            ? (_isPointingHold(lm) || _isPointing(lm) || _isThumbIndexOpen(lm))
+            : (_isPointing(lm)     || _isThumbIndexOpen(lm))
+          // 핀치도 히스테리시스 — 포인터 섹션에서는 wasPinching을 미리 읽고, 제스처 섹션에서 갱신
+          const pinching = !pointing && _isPinching(lm, wasPinching[activeLabel])
+          wasPointing[activeLabel] = pointing
 
-          if (pointing || pinching) {
+          // 신뢰도 낮은 감지 무시 (화면 가장자리, 손 일부 잘림 등)
+          const handScore = handed[activeIdx]?.score ?? 1
+          if (handScore < 0.7) {
+            if (!hideTimers[activeLabel]) {
+              hideTimers[activeLabel] = setTimeout(() => {
+                hideTimers[activeLabel] = null
+                wasActive[activeLabel]  = false
+                pointerRef.current?.(null)
+              }, CURSOR_HIDE_DELAY_MS)
+            }
+          } else if (pointing || pinching) {
             clearTimeout(hideTimers[activeLabel])
             hideTimers[activeLabel] = null
 
-            const px = (lm[5].x + lm[9].x + lm[13].x + lm[17].x) / 4
-            const py = (lm[5].y + lm[9].y + lm[13].y + lm[17].y) / 4
+            // 손목(0)↔중지MCP(9) 중간점 — 손 자세에 가장 안정적
+            const px = (lm[0].x + lm[9].x) / 2
+            const py = (lm[0].y + lm[9].y) / 2
 
             if (Number.isFinite(px) && Number.isFinite(py)) {
-              if (!wasActive[activeLabel]) anchors[activeLabel] = { x: px, y: py }
+              // 재활성화 시 OneEuro 리셋 — 이전 상태가 남아 있으면 커서 점프 발생
+              if (!wasActive[activeLabel]) resetPointerState(pointerStates[activeLabel])
               wasActive[activeLabel] = true
 
-              const anchor   = anchors[activeLabel]
-              const relX     = (px - anchor.x) / ANCHOR_WINDOW_HALF
-              const relY     = (py - anchor.y) / ANCHOR_WINDOW_HALF
-              const baseX    = POINTER_MIRROR_X ? (1 - anchor.x) : anchor.x
-              const dirX     = POINTER_MIRROR_X ? -1 : 1
-              const rawNormX = baseX + relX * 0.5 * dirX
-              const rawNormY = anchor.y + relY * 0.5
-              // 커서가 화면 끝을 벗어나면 앵커를 손 방향으로 조금씩 이동
-              // → 클러칭 없이 화면 끝 너머로 계속 이동 가능
-              if (rawNormX > 1 || rawNormX < 0)
-                anchor.x += (px - anchor.x) * EDGE_FOLLOW_RATE
-              if (rawNormY > 1 || rawNormY < 0)
-                anchor.y += (py - anchor.y) * EDGE_FOLLOW_RATE
-              const normX  = Math.max(0, Math.min(1, rawNormX))
-              const normY  = Math.max(0, Math.min(1, rawNormY))
+              // 절대 선형 매핑 — 방향별 마진 개별 적용
+              const normX = Math.max(0, Math.min(1, (px - CAM_MARGIN_L)   / CAM_ACTIVE_X))
+              const normY = Math.max(0, Math.min(1, (py - CAM_MARGIN_TOP) / CAM_ACTIVE_Y))
               const [sx, sy] = smoothPointer(
                 pointerStates[activeLabel], normX, normY, performance.now() / 1000
               )
@@ -407,7 +559,6 @@ export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enable
               clearTimeout(hideTimers[activeLabel])
               hideTimers[activeLabel] = null
               wasActive[activeLabel]  = false
-              anchors[activeLabel]    = null
               pointerRef.current?.(null)
             }
           } else {
@@ -415,7 +566,6 @@ export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enable
               hideTimers[activeLabel] = setTimeout(() => {
                 hideTimers[activeLabel] = null
                 wasActive[activeLabel]  = false
-                anchors[activeLabel]    = null
                 pointerRef.current?.(null)
               }, CURSOR_HIDE_DELAY_MS)
             }
@@ -436,11 +586,13 @@ export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enable
           clearTimeout(hideTimers[lbl])
           hideTimers[lbl]       = null
           resetPointerState(pointerStates[lbl])
-          anchors[lbl]          = null
           wasActive[lbl]        = false
+          wasPointing[lbl]      = false
+          wasPinching[lbl]      = false
           gestureStates[lbl]    = makeGestureState()
           palmBufs[lbl].length  = 0
           lastSwipeDirs[lbl]    = null
+          okNeedsOpen[lbl]      = false
         }
       }
 
@@ -464,6 +616,7 @@ export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enable
       for (let i = 0; i < lms.length; i++) {
         const lm = lms[i]
         if (!_isValidLandmarks(lm)) continue
+        if (_palmSize(lm) < MIN_PALM_SIZE) continue   // 너무 먼 손 무시
         const mpLabel = handed[i]?.label || 'Right'
         const side    = mpLabel === 'Left' ? 'right' : 'left'
 
@@ -475,8 +628,15 @@ export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enable
         while (palmBufs[mpLabel].length && palmBufs[mpLabel][0].t < cutoff)
           palmBufs[mpLabel].shift()
 
+        // 핀치 히스테리시스 적용 — 이전 프레임 핀치 여부를 넘겨 유지 임계 사용
+        const pinching = _isPinching(lm, wasPinching[mpLabel])
+        wasPinching[mpLabel] = pinching
+
+        // ok 리셋 플래그: 핀치 해제되면 다시 허용
+        if (!pinching) okNeedsOpen[mpLabel] = false
+
         let gesture = null
-        const swipe = _detectSwipe(palmBufs[mpLabel], lastSwipes[mpLabel], lastSwipeDirs[mpLabel], lm)
+        const swipe = _detectSwipe(palmBufs[mpLabel], lastSwipes[mpLabel], lastSwipeDirs[mpLabel], lm, camAR)
         if (swipe) {
           lastSwipes[mpLabel]              = frameNow
           lastSwipeDirs[mpLabel]           = swipe
@@ -485,8 +645,13 @@ export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enable
           gestureStates[mpLabel].count     = 0
           gesture = swipe
         } else {
-          gesture = _confirmStatic(gestureStates[mpLabel], _classifyStatic(lm))
+          // _classifyStatic 내부의 _isPinching도 히스테리시스 적용
+          const raw     = pinching ? 'ok' : _classifyStaticNoPinch(lm)
+          const blocked = (raw === 'ok' && okNeedsOpen[mpLabel]) ? null : raw
+          gesture = _confirmStatic(gestureStates[mpLabel], blocked)
         }
+
+        if (gesture === 'ok') okNeedsOpen[mpLabel] = true
 
         handData[side] = {
           gesture,
@@ -507,6 +672,11 @@ export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enable
         total_fingers: Object.values(handData).reduce((s, d) => s + d.finger_count, 0),
         gesture:       dominant,
       })
+
+      // PiP 캔버스에 인식 영상 + 관절 그리기
+      if (pipCanvasRef?.current && video) {
+        try { _drawPip(pipCanvasRef.current, video, lms, handed) } catch {}
+      }
     }
 
     // inflight 워치독
@@ -546,10 +716,16 @@ export function useGesture({ onPointer, onGesture, onLandmarks, videoRef, enable
         if (!active) return
         if (videoRef) videoRef.current = video
 
+        // 실제 카메라 비율 측정 — 이후 모든 제스처 계산에 적용
+        if (video.videoWidth && video.videoHeight) {
+          camAR = video.videoWidth / video.videoHeight
+          console.log(`[useGesture] 카메라 비율: ${video.videoWidth}×${video.videoHeight} (AR=${camAR.toFixed(3)})`)
+        }
+
         hands = new Hands({ locateFile: (f) => `${MP_BASE}${f}` })
         hands.setOptions({
           maxNumHands:            2,
-          modelComplexity:        1,
+          modelComplexity:        0,
           minDetectionConfidence: 0.6,
           minTrackingConfidence:  0.5,
         })

--- a/frontend/src/screens/MenuScreen.jsx
+++ b/frontend/src/screens/MenuScreen.jsx
@@ -24,7 +24,7 @@ const CAT_I18N_KEY = {
   drink:       'cat_drink',
 }
 
-export default function MenuScreen({ cart, total, addToCart, updateQty, clearCart, nav, chatOpen, swipeRef }) {
+export default function MenuScreen({ cart, total, addToCart, updateQty, clearCart, nav, chatOpen, swipeRef, modalRef }) {
   const t = useT()
   const { menuData, isLoading, error, retry } = useMenuData()
 
@@ -68,6 +68,17 @@ export default function MenuScreen({ cart, total, addToCart, updateQty, clearCar
   useEffect(() => {
     setPage(p => Math.min(p, Math.max(0, totalPages - 1)))
   }, [totalPages])
+
+  // 단품/세트 선택 모달이 열려 있는 동안만 modalRef 에 핸들러 등록
+  useEffect(() => {
+    if (!modalRef) return
+    if (modalStep === 'singleSet') {
+      modalRef.current = (type) => { handleTypeSelect(type) }
+    } else {
+      modalRef.current = null
+    }
+    return () => { if (modalRef) modalRef.current = null }
+  }, [modalRef, modalStep])
 
   // 제스처 스와이프 핸들러 — App.jsx 가 ref 를 통해 호출
   useEffect(() => {

--- a/frontend/src/screens/MenuScreen.jsx
+++ b/frontend/src/screens/MenuScreen.jsx
@@ -1,4 +1,4 @@
-﻿import { useState, useEffect, useRef } from 'react'
+﻿import { useState, useEffect, useRef, useCallback } from 'react'
 import Logo from '../components/Logo'
 import ReturnToStartDialog from '../components/ReturnToStartDialog'
 import SingleSetModal from '../components/SingleSetModal'
@@ -24,7 +24,7 @@ const CAT_I18N_KEY = {
   drink:       'cat_drink',
 }
 
-export default function MenuScreen({ cart, total, addToCart, updateQty, clearCart, nav, chatOpen }) {
+export default function MenuScreen({ cart, total, addToCart, updateQty, clearCart, nav, chatOpen, swipeRef }) {
   const t = useT()
   const { menuData, isLoading, error, retry } = useMenuData()
 
@@ -34,7 +34,9 @@ export default function MenuScreen({ cart, total, addToCart, updateQty, clearCar
   const [modalItem, setModalItem] = useState(null)
   const [modalStep, setModalStep] = useState(null)   // 'singleSet' | 'detail'
   const [modalType, setModalType] = useState('single')
-  const swipeStartX = useRef(null)
+  const swipeStartX  = useRef(null)
+  const lastNavRef   = useRef(-Infinity)
+  const NAV_COOLDOWN = 800  // ms
 
   const handleItemTap = (item) => {
     setModalItem(item)
@@ -66,6 +68,41 @@ export default function MenuScreen({ cart, total, addToCart, updateQty, clearCar
   useEffect(() => {
     setPage(p => Math.min(p, Math.max(0, totalPages - 1)))
   }, [totalPages])
+
+  // 제스처 스와이프 핸들러 — App.jsx 가 ref 를 통해 호출
+  useEffect(() => {
+    if (!swipeRef || !menuData) return
+    const cats = menuData.categories ?? []
+    swipeRef.current = (dir) => {
+      const now = performance.now()
+      if (now - lastNavRef.current < NAV_COOLDOWN) return
+      lastNavRef.current = now
+      if (dir === 'left') {
+        if (page < totalPages - 1) {
+          setPage(p => p + 1)
+        } else {
+          const idx = cats.findIndex(c => c.id === catId)
+          if (idx < cats.length - 1) {
+            setCatId(cats[idx + 1].id)
+            setPage(0)
+          }
+        }
+      } else {
+        if (page > 0) {
+          setPage(p => p - 1)
+        } else {
+          const idx = cats.findIndex(c => c.id === catId)
+          if (idx > 0) {
+            const prevCat   = cats[idx - 1]
+            const prevItems = menuData.menuItems?.[prevCat.id] ?? []
+            const prevTotal = Math.max(1, Math.ceil(prevItems.length / itemsPerPage))
+            setCatId(prevCat.id)
+            setPage(prevTotal - 1)
+          }
+        }
+      }
+    }
+  }, [swipeRef, page, totalPages, catId, menuData, itemsPerPage])
 
   if (isLoading) {
     return (

--- a/frontend/src/screens/StartScreen.jsx
+++ b/frontend/src/screens/StartScreen.jsx
@@ -9,11 +9,41 @@ const LANGS = [
   { code: 'ja', label: '日本語' },
 ]
 
-export default function StartScreen({ nav }) {
+export default function StartScreen({
+  nav,
+  gestureEnabled, setGestureEnabled,
+  pipEnabled,     setPipEnabled,
+}) {
   const { locale, setLocale } = useLocale()
   const t = useT()
 
   useEffect(() => { setLocale('ko') }, [])
+
+  // 작은 토글 버튼 스타일
+  const toggleBtn = (active, disabled = false) => ({
+    padding: '8px 14px',
+    background: disabled
+      ? 'rgba(255,255,255,0.18)'
+      : active ? 'rgba(80,200,140,0.92)' : 'rgba(40,40,40,0.78)',
+    color: disabled ? 'rgba(255,255,255,0.55)' : '#fff',
+    border: '1.5px solid rgba(255,255,255,0.55)',
+    borderRadius: 22,
+    fontSize: 13,
+    fontWeight: 600,
+    cursor: disabled ? 'not-allowed' : 'pointer',
+    textShadow: '0 1px 2px rgba(0,0,0,0.6)',
+    boxShadow: '0 2px 8px rgba(0,0,0,0.3)',
+    display: 'flex', alignItems: 'center', gap: 6,
+    transition: 'background 0.18s',
+  })
+
+  const dot = (on) => (
+    <span style={{
+      width: 8, height: 8, borderRadius: '50%',
+      background: on ? '#7fff9f' : 'rgba(255,255,255,0.4)',
+      boxShadow: on ? '0 0 6px #7fff9f' : 'none',
+    }} />
+  )
 
   return (
     <div
@@ -33,6 +63,35 @@ export default function StartScreen({ nav }) {
         padding: '0 36px 78px',
       }}
     >
+      {/* 설정 토글 — 좌측 상단 */}
+      {setGestureEnabled && (
+        <div
+          onClick={e => e.stopPropagation()}
+          style={{
+            position: 'absolute',
+            top: 16, left: 16,
+            display: 'flex', gap: 8,
+            zIndex: 10,
+          }}
+        >
+          <button
+            onClick={() => setGestureEnabled(v => !v)}
+            style={toggleBtn(gestureEnabled)}
+            title="손동작 인식 켜기/끄기"
+          >
+            {dot(gestureEnabled)} 손동작 {gestureEnabled ? 'ON' : 'OFF'}
+          </button>
+          <button
+            onClick={() => gestureEnabled && setPipEnabled(v => !v)}
+            disabled={!gestureEnabled}
+            style={toggleBtn(pipEnabled && gestureEnabled, !gestureEnabled)}
+            title="카메라 미리보기 켜기/끄기"
+          >
+            {dot(pipEnabled && gestureEnabled)} 카메라 {pipEnabled ? 'ON' : 'OFF'}
+          </button>
+        </div>
+      )}
+
       {/* 주문 시작 버튼 */}
       <button
         onClick={e => { e.stopPropagation(); nav('orderType') }}

--- a/sample/config.py
+++ b/sample/config.py
@@ -1,0 +1,37 @@
+class Config:
+    # --- 카메라 ---
+    CAMERA_ID = 0
+    FRAME_WIDTH = 640
+    FRAME_HEIGHT = 480
+
+    # --- MediaPipe 손 추적 ---
+    MAX_HANDS = 1
+    DETECTION_CONFIDENCE = 0.7
+    TRACKING_CONFIDENCE = 0.5
+
+    # --- 스와이프 감지 ---
+    SWIPE_H_THRESHOLD = 0.11
+    SWIPE_V_THRESHOLD = 0.09
+    SWIPE_AXIS_DOMINANCE = 1.4
+    SWIPE_HISTORY_LEN = 30
+    SWIPE_WINDOW = 14
+    SWIPE_COOLDOWN = 30
+    SWIPE_MIN_FRAMES = 8
+
+    # --- OK 제스처 (~3초 유지) ---
+    OK_DISTANCE_THRESHOLD = 0.07
+    OK_CONFIRM_FRAMES = 85
+
+    # --- 드웰(Dwell) 선택 ---
+    DWELL_FRAMES = 35
+    DWELL_RADIUS = 45
+
+    # --- 포인팅 커서 ---
+    CURSOR_ALPHA = 0.60
+
+    # --- 키오스크 UI ---
+    KIOSK_WIDTH = 420
+    KIOSK_HEIGHT = 480
+
+    # --- 윈도우 ---
+    WINDOW_NAME = "Gesture Kiosk — Barrier-Free Demo"

--- a/sample/gesture_detector.py
+++ b/sample/gesture_detector.py
@@ -1,0 +1,220 @@
+import math
+from collections import deque
+from enum import Enum
+from typing import Optional
+
+import numpy as np
+
+
+class GestureType(Enum):
+    NONE = "none"
+    SWIPE_UP = "swipe_up"
+    SWIPE_DOWN = "swipe_down"
+    SWIPE_LEFT = "swipe_left"
+    SWIPE_RIGHT = "swipe_right"
+    POINT = "point"   # 검지만 펼침 — 커서 이동
+    DWELL = "dwell"   # 커서 일정 시간 고정 — 항목 자동 선택
+    OK = "ok"         # OK 제스처 — 결제 확인
+
+
+class GestureDetector:
+    def __init__(self, config):
+        self._cfg = config
+        # 정규화된 (nx, ny) 위치 히스토리 — 스와이프용
+        self._history: deque = deque(maxlen=config.SWIPE_HISTORY_LEN)
+        self._swipe_cooldown = 0
+        self._ok_frames = 0
+        self._smooth_cursor = None  # type: Optional[list]
+
+        # 드웰 추적
+        self._dwell_anchor = None   # 드웰 시작 커서 위치 (kiosk 좌표)
+        self._dwell_frames = 0
+
+    # ------------------------------------------------------------------ #
+    # public API
+    # ------------------------------------------------------------------ #
+
+    def detect(self, landmarks, frame_shape):
+        """
+        (GestureType, data) 튜플 반환.
+
+        data 구조:
+          POINT  → {"cursor": (kx,ky), "progress": float 0~1}
+          DWELL  → {"cursor": (kx,ky)}
+          기타   → None
+        """
+        if landmarks is None:
+            self._reset_all()
+            return GestureType.NONE, None
+
+        if self._swipe_cooldown > 0:
+            self._swipe_cooldown -= 1
+
+        # 팜 센터(손바닥 중심)를 스와이프 기준점으로 사용 — 손목보다 안정적
+        palm = self._palm_center(landmarks)
+        h, w = frame_shape[:2]
+        self._history.append((palm[0] / w, palm[1] / h))  # 정규화 좌표 저장
+
+        # ── 1. OK 제스처 (결제 확인, 최우선) ─────────────────────────────
+        if self._is_ok(landmarks, frame_shape):
+            self._ok_frames += 1
+            self._reset_dwell()
+            progress = min(1.0, self._ok_frames / self._cfg.OK_CONFIRM_FRAMES)
+            if self._ok_frames >= self._cfg.OK_CONFIRM_FRAMES:
+                self._ok_frames = 0
+                self._history.clear()
+                return GestureType.OK, None
+            # 판정 전까지 진행률만 반환 (UI 피드백용)
+            return GestureType.NONE, {"ok_progress": progress}
+        self._ok_frames = 0
+
+        # ── 2. 포인팅 + 드웰 (검지 펼침) ─────────────────────────────────
+        if self._is_pointing(landmarks):
+            cursor = self._map_cursor(landmarks, frame_shape)
+            progress = self._update_dwell(cursor)
+
+            if progress >= 1.0:
+                self._reset_dwell()
+                self._history.clear()
+                return GestureType.DWELL, {"cursor": cursor}
+
+            return GestureType.POINT, {"cursor": cursor, "progress": progress}
+
+        # 포인팅이 아니면 드웰 초기화
+        self._reset_dwell()
+
+        # ── 3. 스와이프 (열린 손바닥 상태에서만 인정) ────────────────────
+        if self._swipe_cooldown == 0 and self._is_open_palm(landmarks):
+            swipe = self._detect_swipe()
+            if swipe != GestureType.NONE:
+                self._swipe_cooldown = self._cfg.SWIPE_COOLDOWN
+                self._history.clear()
+                return swipe, None
+
+        return GestureType.NONE, None
+
+    # ------------------------------------------------------------------ #
+    # 손 상태 분류
+    # ------------------------------------------------------------------ #
+
+    def _palm_center(self, lms):
+        """손바닥 중심: 손목 + 4개 손가락 MCP 관절의 평균."""
+        idxs = [0, 5, 9, 13, 17]
+        xs = sum(lms[i][0] for i in idxs) / len(idxs)
+        ys = sum(lms[i][1] for i in idxs) / len(idxs)
+        return (int(xs), int(ys))
+
+    def _finger_states(self, lms):
+        """[index_up, middle_up, ring_up, pinky_up] 불리언 리스트."""
+        tips = [8, 12, 16, 20]
+        pips = [6, 10, 14, 18]
+        return [lms[t][1] < lms[p][1] for t, p in zip(tips, pips)]
+
+    def _norm_dist(self, lms, i, j, frame_shape):
+        h, w = frame_shape[:2]
+        p1 = np.array([lms[i][0] / w, lms[i][1] / h])
+        p2 = np.array([lms[j][0] / w, lms[j][1] / h])
+        return float(np.linalg.norm(p1 - p2))
+
+    def _is_ok(self, lms, frame_shape):
+        """엄지-검지 팁이 가깝고, 나머지 손가락 2개 이상 펼쳐진 경우."""
+        if self._norm_dist(lms, 4, 8, frame_shape) >= self._cfg.OK_DISTANCE_THRESHOLD:
+            return False
+        return sum(self._finger_states(lms)[1:]) >= 2
+
+    def _is_pointing(self, lms):
+        """검지만 펼치고 나머지(중지·약지·소지)는 접힌 경우."""
+        s = self._finger_states(lms)
+        return s[0] and not s[1] and not s[2] and not s[3]
+
+    def _is_open_palm(self, lms):
+        """손가락 3개 이상 펼쳐진 경우 — 스와이프용 열린 손 확인."""
+        return sum(self._finger_states(lms)) >= 3
+
+    # ------------------------------------------------------------------ #
+    # 스와이프 감지 (정규화 좌표 + 축 우세 판정)
+    # ------------------------------------------------------------------ #
+
+    def _detect_swipe(self):
+        if len(self._history) < self._cfg.SWIPE_MIN_FRAMES:
+            return GestureType.NONE
+
+        arr = np.array(self._history)
+        # 슬라이딩 윈도우: 전체 히스토리가 아닌 최근 N프레임만 사용
+        # → 손이 화면에 오래 머물다가 스와이프해도 정확하게 인식
+        window = min(len(arr), self._cfg.SWIPE_WINDOW)
+        recent = arr[-window:]
+
+        ndx = float(recent[-1][0] - recent[0][0])
+        ndy = float(recent[-1][1] - recent[0][1])
+        abs_dx, abs_dy = abs(ndx), abs(ndy)
+
+        dominance = self._cfg.SWIPE_AXIS_DOMINANCE
+
+        if abs_dx >= abs_dy * dominance:
+            if abs_dx < self._cfg.SWIPE_H_THRESHOLD:
+                return GestureType.NONE
+            return GestureType.SWIPE_RIGHT if ndx > 0 else GestureType.SWIPE_LEFT
+
+        elif abs_dy >= abs_dx * dominance:
+            if abs_dy < self._cfg.SWIPE_V_THRESHOLD:
+                return GestureType.NONE
+            return GestureType.SWIPE_DOWN if ndy > 0 else GestureType.SWIPE_UP
+
+        return GestureType.NONE  # 대각선 움직임 → 무시
+
+    # ------------------------------------------------------------------ #
+    # 드웰 추적
+    # ------------------------------------------------------------------ #
+
+    def _update_dwell(self, cursor):
+        """커서 위치가 앵커 반경 안에 머물면 카운트를 올리고 진행률(0~1)을 반환한다."""
+        if self._dwell_anchor is None:
+            self._dwell_anchor = cursor
+            self._dwell_frames = 1
+            return 0.0
+
+        dist = math.hypot(cursor[0] - self._dwell_anchor[0],
+                          cursor[1] - self._dwell_anchor[1])
+
+        if dist > self._cfg.DWELL_RADIUS:
+            # 너무 많이 움직였으면 앵커 갱신
+            self._dwell_anchor = cursor
+            self._dwell_frames = 1
+            return 0.0
+
+        self._dwell_frames += 1
+        return min(1.0, self._dwell_frames / self._cfg.DWELL_FRAMES)
+
+    def _reset_dwell(self):
+        self._dwell_anchor = None
+        self._dwell_frames = 0
+
+    # ------------------------------------------------------------------ #
+    # 커서 좌표 매핑 + 스무딩
+    # ------------------------------------------------------------------ #
+
+    def _map_cursor(self, lms, frame_shape):
+        h, w = frame_shape[:2]
+        kw, kh = self._cfg.KIOSK_WIDTH, self._cfg.KIOSK_HEIGHT
+        tip = lms[8]  # INDEX_TIP
+
+        raw = [int(tip[0] / w * kw), int(tip[1] / h * kh)]
+        raw[0] = max(0, min(kw - 1, raw[0]))
+        raw[1] = max(0, min(kh - 1, raw[1]))
+
+        if self._smooth_cursor is None:
+            self._smooth_cursor = raw[:]
+        else:
+            a = self._cfg.CURSOR_ALPHA
+            self._smooth_cursor[0] = int(a * self._smooth_cursor[0] + (1 - a) * raw[0])
+            self._smooth_cursor[1] = int(a * self._smooth_cursor[1] + (1 - a) * raw[1])
+
+        return tuple(self._smooth_cursor)
+
+    def _reset_all(self):
+        self._history.clear()
+        self._ok_frames = 0
+        self._swipe_cooldown = max(0, self._swipe_cooldown - 1)
+        self._smooth_cursor = None
+        self._reset_dwell()

--- a/sample/hand_tracker.py
+++ b/sample/hand_tracker.py
@@ -1,0 +1,53 @@
+import cv2
+import mediapipe as mp
+import numpy as np
+
+
+class HandTracker:
+    """MediaPipe Hands 래퍼. 프레임에서 손 랜드마크를 추출한다."""
+
+    # MediaPipe 21개 랜드마크 인덱스 상수
+    WRIST = 0
+    THUMB_TIP = 4
+    INDEX_TIP = 8;  INDEX_PIP = 6;  INDEX_MCP = 5
+    MIDDLE_TIP = 12; MIDDLE_PIP = 10
+    RING_TIP = 16;   RING_PIP = 14
+    PINKY_TIP = 20;  PINKY_PIP = 18
+
+    def __init__(self, config):
+        mp_hands = mp.solutions.hands
+        self._hands = mp_hands.Hands(
+            max_num_hands=config.MAX_HANDS,
+            min_detection_confidence=config.DETECTION_CONFIDENCE,
+            min_tracking_confidence=config.TRACKING_CONFIDENCE,
+        )
+        self._draw = mp.solutions.drawing_utils
+        self._draw_styles = mp.solutions.drawing_styles
+        self._mp_hands = mp_hands
+
+    def process(self, bgr_frame):
+        """BGR 프레임을 받아 MediaPipe 결과를 반환한다."""
+        rgb = cv2.cvtColor(bgr_frame, cv2.COLOR_BGR2RGB)
+        rgb.flags.writeable = False
+        results = self._hands.process(rgb)
+        rgb.flags.writeable = True
+        return results
+
+    def get_landmarks(self, results, frame_shape):
+        """첫 번째 손의 픽셀 좌표 랜드마크 리스트(21개)를 반환한다. 없으면 None."""
+        if not results.multi_hand_landmarks:
+            return None
+        h, w = frame_shape[:2]
+        lms = results.multi_hand_landmarks[0].landmark
+        return [(int(lm.x * w), int(lm.y * h)) for lm in lms]
+
+    def draw(self, frame, results):
+        """카메라 프레임 위에 손 랜드마크와 연결선을 그린다."""
+        if not results.multi_hand_landmarks:
+            return
+        for hand_lms in results.multi_hand_landmarks:
+            self._draw.draw_landmarks(
+                frame, hand_lms, self._mp_hands.HAND_CONNECTIONS,
+                self._draw_styles.get_default_hand_landmarks_style(),
+                self._draw_styles.get_default_hand_connections_style(),
+            )

--- a/sample/main.py
+++ b/sample/main.py
@@ -1,0 +1,237 @@
+"""
+Gesture Kiosk — Barrier-Free Demo
+===================================
+실행:  python main.py
+종료:  'q' 키
+
+WebSocket: ws://localhost:8765 으로 제스처 이벤트를 전송합니다.
+React 프론트엔드를 별도 브라우저에서 실행하세요.
+"""
+
+import sys
+import time
+import json
+import asyncio
+import threading
+import cv2
+import numpy as np
+import websockets
+
+from config import Config
+from hand_tracker import HandTracker
+from gesture_detector import GestureDetector, GestureType
+
+
+# ── WebSocket 서버 ──────────────────────────────────────────────────────────
+
+_ws_clients: set = set()
+_ws_store: dict = {}   # {'loop': ..., 'queue': ...}
+
+
+async def _ws_handler(websocket):
+    _ws_clients.add(websocket)
+    try:
+        await websocket.wait_closed()
+    finally:
+        _ws_clients.discard(websocket)
+
+
+async def _broadcast_loop(queue: asyncio.Queue):
+    while True:
+        msg = await queue.get()
+        if _ws_clients:
+            await asyncio.gather(
+                *[c.send(msg) for c in list(_ws_clients)],
+                return_exceptions=True,
+            )
+
+
+async def _ws_main():
+    queue: asyncio.Queue = asyncio.Queue()
+    _ws_store["queue"] = queue
+    _ws_store["loop"] = asyncio.get_running_loop()
+
+    async with websockets.serve(_ws_handler, "0.0.0.0", 8765):
+        print("[WS] 제스처 서버 시작 → ws://0.0.0.0:8765 (네트워크 전체 허용)")
+        await _broadcast_loop(queue)
+
+
+def _start_ws_thread():
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(_ws_main())
+
+
+def broadcast(cfg: Config, gesture: GestureType, data):
+    """제스처 이벤트를 모든 WebSocket 클라이언트에게 전송한다."""
+    if "loop" not in _ws_store or "queue" not in _ws_store:
+        return
+
+    cursor_norm = None
+    progress = 0.0
+    ok_progress = 0.0
+
+    if data and isinstance(data, dict):
+        cursor = data.get("cursor")
+        if cursor:
+            # 정규화 좌표 (0~1) — React 측에서 화면 크기에 맞게 변환
+            cursor_norm = [
+                cursor[0] / cfg.KIOSK_WIDTH,
+                cursor[1] / cfg.KIOSK_HEIGHT,
+            ]
+        progress = data.get("progress", 0.0)
+        ok_progress = data.get("ok_progress", 0.0)
+
+    msg = json.dumps({
+        "gesture": gesture.value,
+        "cursor": cursor_norm,
+        "progress": progress,
+        "ok_progress": ok_progress,
+    })
+    _ws_store["loop"].call_soon_threadsafe(_ws_store["queue"].put_nowait, msg)
+
+
+# ── 카메라 HUD ──────────────────────────────────────────────────────────────
+
+GESTURE_LABEL = {
+    GestureType.SWIPE_UP:    "↑ 위 스와이프",
+    GestureType.SWIPE_DOWN:  "↓ 아래 스와이프",
+    GestureType.SWIPE_LEFT:  "← 왼쪽 스와이프",
+    GestureType.SWIPE_RIGHT: "→ 오른쪽 스와이프",
+    GestureType.POINT:       "☞ 포인팅",
+    GestureType.DWELL:       "✅ 선택!",
+    GestureType.OK:          "👌 OK",
+    GestureType.NONE:        "",
+}
+
+GESTURE_COLOR = {
+    GestureType.SWIPE_UP:    (0, 200, 100),
+    GestureType.SWIPE_DOWN:  (0, 200, 100),
+    GestureType.SWIPE_LEFT:  (0, 160, 220),
+    GestureType.SWIPE_RIGHT: (0, 160, 220),
+    GestureType.POINT:       (200, 140, 0),
+    GestureType.DWELL:       (0,  220, 100),
+    GestureType.OK:          (0,  180, 60),
+    GestureType.NONE:        (200, 200, 200),
+}
+
+
+def overlay_hud(frame: np.ndarray, gesture: GestureType, fps: float,
+                ok_progress: float = 0.0):
+    h, w = frame.shape[:2]
+    label = GESTURE_LABEL.get(gesture, "")
+    color = GESTURE_COLOR.get(gesture, (200, 200, 200))
+
+    if label:
+        cv2.rectangle(frame, (8, h - 44), (min(len(label) * 14 + 20, w - 8), h - 8),
+                      (0, 0, 0), -1)
+        cv2.putText(frame, label, (14, h - 16),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.7, color, 2, cv2.LINE_AA)
+
+    cv2.putText(frame, f"FPS {fps:.0f}", (8, 24),
+                cv2.FONT_HERSHEY_SIMPLEX, 0.55, (180, 255, 180), 1, cv2.LINE_AA)
+
+    if ok_progress > 0.0:
+        bar_w = 200
+        bx = w // 2 - bar_w // 2
+        by = h - 18
+        cv2.rectangle(frame, (bx, by), (bx + bar_w, by + 10), (40, 40, 40), -1)
+        filled = int(bar_w * ok_progress)
+        cv2.rectangle(frame, (bx, by), (bx + filled, by + 10), (0, 220, 80), -1)
+        cv2.putText(frame, "OK holding...", (bx, by - 6),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.45, (0, 220, 80), 1, cv2.LINE_AA)
+
+    # WS 연결 상태 표시
+    client_count = len(_ws_clients)
+    ws_color = (0, 220, 80) if client_count > 0 else (0, 100, 200)
+    ws_text = f"WS {client_count} connected" if client_count > 0 else "WS waiting..."
+    cv2.putText(frame, ws_text, (8, 48),
+                cv2.FONT_HERSHEY_SIMPLEX, 0.45, ws_color, 1, cv2.LINE_AA)
+
+
+def overlay_guide(frame: np.ndarray):
+    guides = [
+        "↑↓ Swipe : scroll/category",
+        "← Swipe  : back",
+        "→ Swipe  : next/select",
+        "Point    : cursor",
+        "Dwell 1s : select",
+        "OK       : confirm",
+    ]
+    x, y0 = frame.shape[1] - 200, 10
+    for i, g in enumerate(guides):
+        cv2.putText(frame, g, (x, y0 + i * 20),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.4, (200, 220, 255), 1, cv2.LINE_AA)
+
+
+# ── 메인 루프 ───────────────────────────────────────────────────────────────
+
+def run():
+    cfg = Config()
+
+    # WebSocket 서버를 백그라운드 스레드에서 시작
+    ws_thread = threading.Thread(target=_start_ws_thread, daemon=True)
+    ws_thread.start()
+
+    cap = cv2.VideoCapture(cfg.CAMERA_ID)
+    if not cap.isOpened():
+        print("[ERROR] 카메라를 열 수 없습니다. CAMERA_ID를 확인하세요.")
+        sys.exit(1)
+
+    cap.set(cv2.CAP_PROP_FRAME_WIDTH,  cfg.FRAME_WIDTH)
+    cap.set(cv2.CAP_PROP_FRAME_HEIGHT, cfg.FRAME_HEIGHT)
+
+    tracker  = HandTracker(cfg)
+    detector = GestureDetector(cfg)
+
+    cv2.namedWindow(cfg.WINDOW_NAME, cv2.WINDOW_NORMAL)
+    cv2.resizeWindow(cfg.WINDOW_NAME, cfg.FRAME_WIDTH, cfg.FRAME_HEIGHT)
+
+    prev_time = time.time()
+    last_gesture = GestureType.NONE
+
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            print("[WARN] 프레임 읽기 실패")
+            continue
+
+        frame = cv2.flip(frame, 1)
+
+        results  = tracker.process(frame)
+        landmarks = tracker.get_landmarks(results, frame.shape)
+        gesture, data = detector.detect(landmarks, frame.shape)
+
+        # 모든 프레임마다 WebSocket으로 상태 전송 (NONE 포함)
+        broadcast(cfg, gesture, data)
+
+        ok_progress = 0.0
+        if data and isinstance(data, dict):
+            ok_progress = data.get("ok_progress", 0.0)
+
+        if gesture != GestureType.NONE:
+            last_gesture = gesture
+        elif last_gesture != GestureType.NONE:
+            last_gesture = GestureType.NONE
+
+        tracker.draw(frame, results)
+
+        now = time.time()
+        fps = 1.0 / max(now - prev_time, 1e-5)
+        prev_time = now
+
+        display_gesture = gesture if gesture != GestureType.NONE else last_gesture
+        overlay_hud(frame, display_gesture, fps, ok_progress)
+        overlay_guide(frame)
+
+        cv2.imshow(cfg.WINDOW_NAME, frame)
+
+        if cv2.waitKey(1) & 0xFF == ord('q'):
+            break
+
+    cap.release()
+    cv2.destroyAllWindows()
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
This pull request introduces significant improvements to both the gesture recognition backend (`gesture_module_API.py`) and the React frontend, focusing on more robust, responsive, and user-friendly hand gesture controls. The main changes include a major refactor of gesture pointer and "OK" gesture UI handling, new support for edge auto-scrolling, and improved communication between gesture events and menu navigation.

**Key changes include:**

### Gesture Recognition Backend Improvements

* Changed "ok" gesture detection to use a rule-based threshold (`PINCH_RULE_THRESHOLD`) instead of ML confidence, making "ok" recognition faster and more reliable. The confirmation frame count for "ok" is reduced from 7 to 4 for quicker response. [[1]](diffhunk://#diff-65268501d85086f11b12659580d19061c58ae8637f7523281bc9a22c60a7ff2bL92-R92) [[2]](diffhunk://#diff-65268501d85086f11b12659580d19061c58ae8637f7523281bc9a22c60a7ff2bL110-R116) [[3]](diffhunk://#diff-65268501d85086f11b12659580d19061c58ae8637f7523281bc9a22c60a7ff2bR345-R372)
* Added output of `pinch_distance` and `is_pointing` in the gesture result dictionary, providing richer gesture state to the frontend.

### Frontend Gesture UI Refactor

* Refactored gesture pointer and "OK" ring to be updated directly via DOM refs, eliminating unnecessary React state and enabling smooth 30fps updates without re-renders. The "OK" ring is now visually managed with conic gradients and is hidden or reset instantly when gestures are disabled. [[1]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L39-R75) [[2]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L97-R214) [[3]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R223-L158) [[4]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L298-L346)
* Added persistent toggles for gesture recognition and PiP (picture-in-picture) preview, storing user preferences in `localStorage` and exposing controls to the `StartScreen`. [[1]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L39-R75) [[2]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R380-R389)
* Added a PiP camera preview canvas in the UI, shown when gesture control and PiP are enabled.

### Edge Auto-Scroll & Pointer Enhancements

* Implemented edge zone detection and auto-scrolling: when the gesture pointer is near a screen edge, the nearest scrollable element (or window) scrolls in that direction, with speed proportional to proximity to the edge. [[1]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L39-R75) [[2]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L97-R214)

### Gesture-Driven Menu Navigation

* Enhanced gesture-driven navigation in the menu screen: swipes and finger gestures are now handled via `swipeRef` and `modalRef` callbacks, allowing for page/tab switching and modal selection (single/set) directly from gestures. Navigation is debounced to prevent rapid accidental transitions. [[1]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R380-R389) [[2]](diffhunk://#diff-f2748c98a7ffda3a1a8f4401de6b390005ce8deed350dfe7f38aa35e507a7365L27-R27) [[3]](diffhunk://#diff-f2748c98a7ffda3a1a8f4401de6b390005ce8deed350dfe7f38aa35e507a7365R38-R39) [[4]](diffhunk://#diff-f2748c98a7ffda3a1a8f4401de6b390005ce8deed350dfe7f38aa35e507a7365R72-R117)

### Miscellaneous

* Cleaned up gesture HUD and label display logic, ensuring gesture labels and counts are always up-to-date and visually consistent. [[1]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L183-L189) [[2]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L298-L346)
* Added a new `asd.txt` file with a Claude resume command (likely for development/testing purposes).

These changes together make the gesture system more robust, responsive, and user-friendly, with a smoother UI and more intuitive navigation.

---

**References:**
- [[1]](diffhunk://#diff-65268501d85086f11b12659580d19061c58ae8637f7523281bc9a22c60a7ff2bL92-R92) [[2]](diffhunk://#diff-65268501d85086f11b12659580d19061c58ae8637f7523281bc9a22c60a7ff2bL110-R116) [[3]](diffhunk://#diff-65268501d85086f11b12659580d19061c58ae8637f7523281bc9a22c60a7ff2bR243-R251) [[4]](diffhunk://#diff-65268501d85086f11b12659580d19061c58ae8637f7523281bc9a22c60a7ff2bR345-R372)
- [[1]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L39-R75) [[2]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L72-R103) [[3]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L97-R214) [[4]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R223-L158) [[5]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L183-L189) [[6]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L232-R355) [[7]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9R380-R389) [[8]](diffhunk://#diff-a0eba768ed9d2a17091f82d46efb5e1c988f08185cc1e9989366995cdb4e3ba9L298-L346)
- [[1]](diffhunk://#diff-f2748c98a7ffda3a1a8f4401de6b390005ce8deed350dfe7f38aa35e507a7365L1-R1) [[2]](diffhunk://#diff-f2748c98a7ffda3a1a8f4401de6b390005ce8deed350dfe7f38aa35e507a7365L27-R27) [[3]](diffhunk://#diff-f2748c98a7ffda3a1a8f4401de6b390005ce8deed350dfe7f38aa35e507a7365R38-R39) [[4]](diffhunk://#diff-f2748c98a7ffda3a1a8f4401de6b390005ce8deed350dfe7f38aa35e507a7365R72-R117)
- [asd.txtR1](diffhunk://#diff-54891b74afff0f07ae8511f4ed4f290830dcc1fe98274f855fb5055fda43546bR1)