### PR TITLE
feat(admin): 관리자 인증·메뉴관리·회원관리 백엔드 구현 (Module A/B/G)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,9 @@ VITE_API_URL=http://localhost:8000
 # ai_modules/llm/api_client.py 에서 사용
 API_BASE_URL=http://localhost:8000
 
+# --- 관리자 인증 ---
+ADMIN_JWT_SECRET=change-me-to-a-random-long-string
+ADMIN_JWT_EXPIRE_MINUTES=480
+ADMIN_BOOTSTRAP_USERNAME=admin
+ADMIN_BOOTSTRAP_PASSWORD=change-me-on-first-login
+

--- a/backend/api/admin/auth.py
+++ b/backend/api/admin/auth.py
@@ -1,0 +1,50 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.db import get_session
+from core.security import (
+    create_access_token,
+    get_current_admin,
+    verify_password,
+)
+from dao.admin_dao import get_admin_by_id, get_admin_by_username, touch_last_login
+from schemas.admin_auth_schemas import AdminMeOut, LoginIn, LoginOut
+
+# 로그인 자체는 인증 없이 호출해야 하므로 이 라우터엔 공통 인증 dependency를 걸지 않는다.
+router = APIRouter(prefix="/api/admin/auth", tags=["admin-auth"])
+
+
+@router.post("/login", response_model=LoginOut)
+async def login(payload: LoginIn, db: AsyncSession = Depends(get_session)):
+    admin = await get_admin_by_username(db, payload.username)
+    if admin is None or not verify_password(payload.password, admin.password_hash):
+        raise HTTPException(401, "아이디 또는 비밀번호가 올바르지 않습니다")
+    if not admin.is_active:
+        raise HTTPException(401, "비활성화된 계정입니다")
+
+    access_token, expires_in = create_access_token(admin.id, admin.role)
+    await touch_last_login(db, admin.id)
+    await db.commit()
+
+    return LoginOut(access_token=access_token, expires_in=expires_in)
+
+
+@router.post("/logout")
+async def logout():
+    return {"ok": True}
+
+
+@router.get("/me", response_model=AdminMeOut)
+async def get_me(
+    admin: dict = Depends(get_current_admin),
+    db: AsyncSession = Depends(get_session),
+):
+    record = await get_admin_by_id(db, admin["id"])
+    if record is None:
+        raise HTTPException(401, "인증 정보가 유효하지 않습니다. 다시 로그인해 주세요.")
+    return AdminMeOut(
+        id=record.id,
+        username=record.username,
+        display_name=record.display_name,
+        role=record.role,
+    )

--- a/backend/api/admin/menu.py
+++ b/backend/api/admin/menu.py
@@ -1,0 +1,170 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ai_modules.llm.rag import invalidate_cache
+from core.db import get_session
+from core.security import get_current_admin
+from dao import menu_dao
+from schemas.menu_schemas import (
+    CategoryIn,
+    CategoryOut,
+    CategoryPatchIn,
+    MenuItemIn,
+    MenuItemOut,
+    MenuItemPatchIn,
+    MenuOptionIn,
+    MenuOptionOut,
+    MenuOptionPatchIn,
+)
+
+router = APIRouter(
+    prefix="/api/admin",
+    tags=["admin-menu"],
+    dependencies=[Depends(get_current_admin)],
+)
+
+
+# --- 카테고리 ---------------------------------------------------------------
+@router.post("/categories", response_model=CategoryOut)
+async def create_category(payload: CategoryIn, db: AsyncSession = Depends(get_session)):
+    category = await menu_dao.create_category(db, payload.model_dump())
+    await db.commit()
+    return category
+
+
+@router.patch("/categories/{category_id}", response_model=CategoryOut)
+async def update_category(
+    category_id: str, payload: CategoryPatchIn, db: AsyncSession = Depends(get_session)
+):
+    category = await menu_dao.get_category_by_id(db, category_id)
+    if category is None:
+        raise HTTPException(404, "카테고리를 찾을 수 없습니다")
+    category = await menu_dao.update_category(
+        db, category, payload.model_dump(exclude_unset=True)
+    )
+    await db.commit()
+    return category
+
+
+@router.delete("/categories/{category_id}")
+async def delete_category(category_id: str, db: AsyncSession = Depends(get_session)):
+    category = await menu_dao.get_category_by_id(db, category_id)
+    if category is None:
+        raise HTTPException(404, "카테고리를 찾을 수 없습니다")
+    if await menu_dao.category_has_menu_items(db, category_id):
+        raise HTTPException(409, "하위 메뉴가 있는 카테고리는 삭제할 수 없습니다")
+
+    try:
+        await menu_dao.delete_category(db, category)
+        await db.commit()
+    except IntegrityError:
+        # 할인(Discount) 등 다른 테이블이 이 카테고리를 참조 중 — 하드 삭제 대신 비노출 처리.
+        await db.rollback()
+        category = await menu_dao.get_category_by_id(db, category_id)
+        await menu_dao.update_category(db, category, {"is_visible": False})
+        await db.commit()
+        raise HTTPException(
+            409, "다른 데이터가 참조 중인 카테고리라 삭제 대신 비노출 처리되었습니다"
+        )
+
+    return {"ok": True}
+
+
+# --- 메뉴 ------------------------------------------------------------------
+@router.post("/menu/items", response_model=MenuItemOut)
+async def create_menu_item(payload: MenuItemIn, db: AsyncSession = Depends(get_session)):
+    item = await menu_dao.create_menu_item(db, payload.model_dump())
+    await db.commit()
+    invalidate_cache()
+    return item
+
+
+@router.patch("/menu/items/{item_id}", response_model=MenuItemOut)
+async def update_menu_item(
+    item_id: str, payload: MenuItemPatchIn, db: AsyncSession = Depends(get_session)
+):
+    item = await menu_dao.get_menu_item_by_id(db, item_id)
+    if item is None:
+        raise HTTPException(404, "메뉴를 찾을 수 없습니다")
+    item = await menu_dao.update_menu_item(db, item, payload.model_dump(exclude_unset=True))
+    await db.commit()
+    invalidate_cache()
+    return item
+
+
+@router.delete("/menu/items/{item_id}")
+async def delete_menu_item(item_id: str, db: AsyncSession = Depends(get_session)):
+    item = await menu_dao.get_menu_item_by_id(db, item_id)
+    if item is None:
+        raise HTTPException(404, "메뉴를 찾을 수 없습니다")
+
+    if await menu_dao.is_menu_item_in_active_order(db, item_id):
+        await menu_dao.soft_delete_menu_item(db, item)
+        await db.commit()
+        invalidate_cache()
+        raise HTTPException(
+            409, "진행 중인 주문에 포함된 메뉴라 삭제 대신 품절 처리되었습니다"
+        )
+
+    try:
+        await menu_dao.hard_delete_menu_item(db, item)
+        await db.commit()
+    except IntegrityError:
+        # 과거 주문/장바구니 등 다른 테이블이 이 메뉴를 참조 중 — 하드 삭제 대신 품절 처리.
+        await db.rollback()
+        item = await menu_dao.get_menu_item_by_id(db, item_id)
+        await menu_dao.soft_delete_menu_item(db, item)
+        await db.commit()
+        invalidate_cache()
+        raise HTTPException(
+            409, "주문 이력이 있는 메뉴라 삭제 대신 품절 처리되었습니다"
+        )
+
+    invalidate_cache()
+    return {"ok": True}
+
+
+# --- 메뉴 옵션 ---------------------------------------------------------------
+@router.post("/menu/items/{item_id}/options", response_model=MenuOptionOut)
+async def create_menu_option(
+    item_id: str, payload: MenuOptionIn, db: AsyncSession = Depends(get_session)
+):
+    item = await menu_dao.get_menu_item_by_id(db, item_id)
+    if item is None:
+        raise HTTPException(404, "메뉴를 찾을 수 없습니다")
+    option = await menu_dao.create_menu_option(db, item_id, payload.model_dump())
+    await db.commit()
+    invalidate_cache()
+    return option
+
+
+@router.patch("/menu/items/{item_id}/options/{option_id}", response_model=MenuOptionOut)
+async def update_menu_option(
+    item_id: str,
+    option_id: str,
+    payload: MenuOptionPatchIn,
+    db: AsyncSession = Depends(get_session),
+):
+    option = await menu_dao.get_menu_option_by_id(db, option_id)
+    if option is None or option.menu_item_id != item_id:
+        raise HTTPException(404, "옵션을 찾을 수 없습니다")
+    option = await menu_dao.update_menu_option(
+        db, option, payload.model_dump(exclude_unset=True)
+    )
+    await db.commit()
+    invalidate_cache()
+    return option
+
+
+@router.delete("/menu/items/{item_id}/options/{option_id}")
+async def delete_menu_option(
+    item_id: str, option_id: str, db: AsyncSession = Depends(get_session)
+):
+    option = await menu_dao.get_menu_option_by_id(db, option_id)
+    if option is None or option.menu_item_id != item_id:
+        raise HTTPException(404, "옵션을 찾을 수 없습니다")
+    await menu_dao.delete_menu_option(db, option)
+    await db.commit()
+    invalidate_cache()
+    return {"ok": True}

--- a/backend/api/admin/users.py
+++ b/backend/api/admin/users.py
@@ -1,0 +1,108 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.db import get_session
+from core.security import get_current_admin
+from dao import order_dao, user_dao
+from schemas.admin_schemas import PointsAdjustIn, UserAdminOut, UserDetailOut
+from schemas.coupon_schemas import UserCouponOut
+from schemas.order_schemas import OrderAdminOut, OrderItemOut
+
+router = APIRouter(
+    prefix="/api/admin/users",
+    tags=["admin-users"],
+    dependencies=[Depends(get_current_admin)],
+)
+
+
+def _to_user_admin_out(user, tier: str | None) -> UserAdminOut:
+    return UserAdminOut(
+        id=user.id,
+        phone_number=user.phone_number,
+        current_points=user.current_points,
+        tier=tier,
+        is_guest=user.is_guest,
+        created_at=str(user.created_at),
+    )
+
+
+def _to_order_admin_out(order) -> OrderAdminOut:
+    latest_payment = max(order.payments, key=lambda p: p.created_at) if order.payments else None
+    return OrderAdminOut(
+        order_id=order.id,
+        order_number=order.order_number,
+        order_type=order.order_type,
+        status=order.status,
+        table_number=order.table_number,
+        subtotal=order.subtotal,
+        discount_amount=order.discount_amount,
+        final_amount=order.final_amount,
+        points_used=order.points_used,
+        points_earned=order.points_earned,
+        created_at=str(order.created_at),
+        items=[
+            OrderItemOut(
+                menu_item_id=item.menu_item_id,
+                name_ko=item.menu_item.name_ko if item.menu_item else "",
+                quantity=item.quantity,
+                unit_price=item.unit_price,
+                total_price=item.total_price,
+                selected_options=item.selected_options or [],
+                special_note=item.special_note,
+            )
+            for item in order.items
+        ],
+        payment_status=latest_payment.status if latest_payment else None,
+    )
+
+
+@router.get("", response_model=list[UserAdminOut])
+async def list_users(phone: str | None = None, db: AsyncSession = Depends(get_session)):
+    users = await user_dao.search_users(db, phone)
+    result = []
+    for user in users:
+        membership = await user_dao.get_membership(db, user.id)
+        result.append(_to_user_admin_out(user, membership.tier if membership else None))
+    return result
+
+
+@router.get("/{user_id}", response_model=UserDetailOut)
+async def get_user_detail(user_id: str, db: AsyncSession = Depends(get_session)):
+    user = await user_dao.get_user_by_id(db, user_id)
+    if user is None:
+        raise HTTPException(404, "등록된 회원이 아닙니다")
+
+    membership = await user_dao.get_membership(db, user.id)
+    recent_orders = await order_dao.get_recent_orders_by_user(db, user.id)
+    coupons = await user_dao.get_all_user_coupons(db, user.id)
+
+    base = _to_user_admin_out(user, membership.tier if membership else None)
+    return UserDetailOut(
+        **base.model_dump(),
+        recent_orders=[_to_order_admin_out(o) for o in recent_orders],
+        coupons=[
+            UserCouponOut(
+                user_coupon_id=uc.id,
+                user_id=uc.user_id,
+                coupon_id=uc.coupon_id,
+                issued_at=str(uc.issued_at),
+            )
+            for uc in coupons
+        ],
+    )
+
+
+@router.patch("/{user_id}/points", response_model=UserAdminOut)
+async def adjust_user_points(
+    user_id: str, payload: PointsAdjustIn, db: AsyncSession = Depends(get_session)
+):
+    if not payload.reason.strip():
+        raise HTTPException(400, "포인트 조정 사유를 입력해 주세요")
+
+    user = await user_dao.adjust_points(db, user_id, payload.delta, payload.reason)
+    if user is None:
+        raise HTTPException(404, "등록된 회원이 아닙니다")
+    await db.commit()
+
+    membership = await user_dao.get_membership(db, user.id)
+    return _to_user_admin_out(user, membership.tier if membership else None)

--- a/backend/core/admin_seed.py
+++ b/backend/core/admin_seed.py
@@ -1,0 +1,30 @@
+"""
+관리자 계정 부트스트랩.
+앱 시작 시 admin_users 테이블이 비어 있으면 .env의 ADMIN_BOOTSTRAP_USERNAME/PASSWORD로
+OWNER 계정 1개를 자동 생성한다(최초 1회, 이후엔 계정이 있으므로 아무 것도 하지 않음).
+"""
+from __future__ import annotations
+
+import os
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dao.admin_dao import count_admins, create_admin
+from .security import hash_password
+
+
+async def seed_admin(db: AsyncSession) -> None:
+    if await count_admins(db) > 0:
+        return
+
+    username = os.getenv("ADMIN_BOOTSTRAP_USERNAME", "admin")
+    password = os.getenv("ADMIN_BOOTSTRAP_PASSWORD", "change-me-on-first-login")
+
+    await create_admin(
+        db,
+        username=username,
+        password_hash=hash_password(password),
+        display_name="관리자",
+        role="OWNER",
+    )
+    await db.commit()

--- a/backend/core/db.py
+++ b/backend/core/db.py
@@ -57,9 +57,11 @@ async def init_db() -> None:
     """앱 시작 시 테이블 생성 + 메뉴 시드."""
     from . import models  # noqa: F401
     from .seed import seed_menu
+    from .admin_seed import seed_admin
 
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 
     async with SessionLocal() as session:
         await seed_menu(session)
+        await seed_admin(session)

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -238,6 +238,14 @@ class Order(Base):
         SAEnum("EAT_IN", "TAKE_OUT", name="order_type"), default="TAKE_OUT"
     )
     table_number: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    status: Mapped[str] = mapped_column(
+        SAEnum("RECEIVED", "COOKING", "READY", "COMPLETED", "CANCELLED", name="order_status"),
+        default="RECEIVED",
+    )
+    # 환불 시 포인트·쿠폰을 정확히 원상복구하려면 이 주문에 어떤 쿠폰을 썼는지가 남아있어야 한다.
+    user_coupon_id: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("user_coupons.id"), nullable=True
+    )
     subtotal: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=0)
     discount_amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=0)
     final_amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=0)
@@ -265,6 +273,7 @@ class OrderItem(Base):
     special_note: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     order: Mapped["Order"] = relationship("Order", back_populates="items")
+    menu_item: Mapped["MenuItem"] = relationship("MenuItem")
 
 
 # --- PAYMENTS ------------------------------------------------------------
@@ -289,3 +298,19 @@ class Payment(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
 
     order: Mapped["Order"] = relationship("Order", back_populates="payments")
+
+
+# --- ADMIN_USERS -----------------------------------------------------------
+class AdminUser(Base):
+    __tablename__ = "admin_users"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    username: Mapped[str] = mapped_column(String(64), unique=True)
+    password_hash: Mapped[str] = mapped_column(String(255))
+    display_name: Mapped[str] = mapped_column(String(64))
+    role: Mapped[str] = mapped_column(
+        SAEnum("OWNER", "STAFF", name="admin_role"), default="STAFF"
+    )
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    last_login_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())

--- a/backend/core/security.py
+++ b/backend/core/security.py
@@ -1,0 +1,47 @@
+"""
+관리자 인증 — 비밀번호 해시 + JWT 발급/검증.
+다른 모듈은 이 파일의 get_current_admin/require_owner만 import해서 쓰면 된다.
+"""
+import os
+from datetime import datetime, timedelta
+
+from fastapi import Depends, HTTPException
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+
+pwd_context = CryptContext(schemes=["bcrypt"])
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/admin/auth/login")
+
+_SECRET = os.getenv("ADMIN_JWT_SECRET", "dev-only-insecure-secret")
+_EXPIRE_MIN = int(os.getenv("ADMIN_JWT_EXPIRE_MINUTES", "480"))
+
+
+def hash_password(raw: str) -> str:
+    return pwd_context.hash(raw)
+
+
+def verify_password(raw: str, hashed: str) -> bool:
+    return pwd_context.verify(raw, hashed)
+
+
+def create_access_token(admin_id: str, role: str) -> tuple[str, int]:
+    expire = datetime.utcnow() + timedelta(minutes=_EXPIRE_MIN)
+    payload = {"sub": admin_id, "role": role, "exp": expire}
+    token = jwt.encode(payload, _SECRET, algorithm="HS256")
+    return token, _EXPIRE_MIN * 60
+
+
+async def get_current_admin(token: str = Depends(oauth2_scheme)) -> dict:
+    """반환값: {"id": admin_id, "role": role}."""
+    try:
+        payload = jwt.decode(token, _SECRET, algorithms=["HS256"])
+        return {"id": payload["sub"], "role": payload["role"]}
+    except JWTError:
+        raise HTTPException(401, "인증 정보가 유효하지 않습니다. 다시 로그인해 주세요.")
+
+
+async def require_owner(admin: dict = Depends(get_current_admin)) -> dict:
+    if admin["role"] != "OWNER":
+        raise HTTPException(403, "관리자(OWNER) 권한이 필요합니다.")
+    return admin

--- a/backend/dao/admin_dao.py
+++ b/backend/dao/admin_dao.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.models import AdminUser
+
+
+async def get_admin_by_username(db: AsyncSession, username: str) -> AdminUser | None:
+    result = await db.execute(
+        select(AdminUser).where(AdminUser.username == username)
+    )
+    return result.scalar_one_or_none()
+
+
+async def get_admin_by_id(db: AsyncSession, admin_id: str) -> AdminUser | None:
+    result = await db.execute(
+        select(AdminUser).where(AdminUser.id == admin_id)
+    )
+    return result.scalar_one_or_none()
+
+
+async def count_admins(db: AsyncSession) -> int:
+    result = await db.execute(select(AdminUser))
+    return len(result.scalars().all())
+
+
+async def create_admin(
+    db: AsyncSession, username: str, password_hash: str, display_name: str, role: str
+) -> AdminUser:
+    admin = AdminUser(
+        username=username,
+        password_hash=password_hash,
+        display_name=display_name,
+        role=role,
+    )
+    db.add(admin)
+    await db.flush()
+    return admin
+
+
+async def touch_last_login(db: AsyncSession, admin_id: str) -> None:
+    admin = await get_admin_by_id(db, admin_id)
+    if admin is not None:
+        admin.last_login_at = datetime.utcnow()
+        await db.flush()

--- a/backend/dao/menu_dao.py
+++ b/backend/dao/menu_dao.py
@@ -1,7 +1,7 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
-from core.models import Category, MenuItem
+from core.models import Category, MenuItem, MenuOption, Order, OrderItem
 
 async def get_all_categories(db: AsyncSession) -> list[Category]:
     result = await db.execute(
@@ -39,3 +39,113 @@ async def get_popular_items(db: AsyncSession) -> list[MenuItem]:
         .options(selectinload(MenuItem.options))
     )
     return result.scalars().all()
+
+
+# --- 관리자용 CRUD (Module B) ------------------------------------------------
+
+_ACTIVE_ORDER_STATUSES = ("RECEIVED", "COOKING", "READY")
+
+
+async def get_all_categories_admin(db: AsyncSession) -> list[Category]:
+    result = await db.execute(select(Category).order_by(Category.display_order))
+    return result.scalars().all()
+
+
+async def get_category_by_id(db: AsyncSession, category_id: str) -> Category | None:
+    result = await db.execute(select(Category).where(Category.id == category_id))
+    return result.scalar_one_or_none()
+
+
+async def create_category(db: AsyncSession, data: dict) -> Category:
+    category = Category(**data)
+    db.add(category)
+    await db.flush()
+    return category
+
+
+async def update_category(db: AsyncSession, category: Category, data: dict) -> Category:
+    for key, value in data.items():
+        setattr(category, key, value)
+    await db.flush()
+    return category
+
+
+async def category_has_menu_items(db: AsyncSession, category_id: str) -> bool:
+    result = await db.execute(
+        select(MenuItem.id).where(MenuItem.category_id == category_id).limit(1)
+    )
+    return result.scalar_one_or_none() is not None
+
+
+async def delete_category(db: AsyncSession, category: Category) -> None:
+    await db.delete(category)
+    await db.flush()
+
+
+async def get_all_menu_items_admin(db: AsyncSession) -> list[MenuItem]:
+    result = await db.execute(
+        select(MenuItem)
+        .options(selectinload(MenuItem.options))
+        .order_by(MenuItem.category_id, MenuItem.display_order)
+    )
+    return result.scalars().all()
+
+
+async def create_menu_item(db: AsyncSession, data: dict) -> MenuItem:
+    item = MenuItem(**data)
+    db.add(item)
+    await db.flush()
+    return item
+
+
+async def update_menu_item(db: AsyncSession, item: MenuItem, data: dict) -> MenuItem:
+    for key, value in data.items():
+        setattr(item, key, value)
+    await db.flush()
+    return item
+
+
+async def is_menu_item_in_active_order(db: AsyncSession, item_id: str) -> bool:
+    """진행 중(접수/조리/픽업대기)인 주문에 이 메뉴가 포함되어 있으면 True."""
+    result = await db.execute(
+        select(OrderItem.id)
+        .join(Order, Order.id == OrderItem.order_id)
+        .where(OrderItem.menu_item_id == item_id)
+        .where(Order.status.in_(_ACTIVE_ORDER_STATUSES))
+        .limit(1)
+    )
+    return result.scalar_one_or_none() is not None
+
+
+async def soft_delete_menu_item(db: AsyncSession, item: MenuItem) -> None:
+    item.is_available = False
+    await db.flush()
+
+
+async def hard_delete_menu_item(db: AsyncSession, item: MenuItem) -> None:
+    await db.delete(item)
+    await db.flush()
+
+
+async def get_menu_option_by_id(db: AsyncSession, option_id: str) -> MenuOption | None:
+    result = await db.execute(select(MenuOption).where(MenuOption.id == option_id))
+    return result.scalar_one_or_none()
+
+
+async def create_menu_option(db: AsyncSession, menu_item_id: str, data: dict) -> MenuOption:
+    option = MenuOption(menu_item_id=menu_item_id, **data)
+    db.add(option)
+    await db.flush()
+    return option
+
+
+async def update_menu_option(db: AsyncSession, option: MenuOption, data: dict) -> MenuOption:
+    for key, value in data.items():
+        setattr(option, key, value)
+    await db.flush()
+    return option
+
+
+async def delete_menu_option(db: AsyncSession, option: MenuOption) -> None:
+    await db.delete(option)
+    await db.flush()

--- a/backend/dao/order_dao.py
+++ b/backend/dao/order_dao.py
@@ -56,3 +56,19 @@ async def get_order_by_id(db: AsyncSession, order_id: str) -> Order | None:
         .options(selectinload(Order.items))
     )
     return result.scalar_one_or_none()
+
+
+async def get_recent_orders_by_user(
+    db: AsyncSession, user_id: str, limit: int = 5
+) -> list[Order]:
+    result = await db.execute(
+        select(Order)
+        .where(Order.user_id == user_id)
+        .options(
+            selectinload(Order.items).selectinload(OrderItem.menu_item),
+            selectinload(Order.payments),
+        )
+        .order_by(Order.created_at.desc())
+        .limit(limit)
+    )
+    return result.scalars().all()

--- a/backend/dao/user_dao.py
+++ b/backend/dao/user_dao.py
@@ -1,6 +1,10 @@
+import logging
+
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from core.models import User, Membership, UserCoupon, Coupon
+
+logger = logging.getLogger(__name__)
 
 async def get_user_by_phone(db: AsyncSession, phone: str) -> User | None:
     result = await db.execute(
@@ -29,3 +33,39 @@ async def get_coupon_by_code(db: AsyncSession, code: str) -> Coupon | None:
         .where(Coupon.is_active == True)
     )
     return result.scalar_one_or_none()
+
+
+# --- 관리자용 (Module G) -----------------------------------------------------
+
+async def get_user_by_id(db: AsyncSession, user_id: str) -> User | None:
+    result = await db.execute(select(User).where(User.id == user_id))
+    return result.scalar_one_or_none()
+
+
+async def search_users(db: AsyncSession, phone: str | None = None) -> list[User]:
+    query = select(User).order_by(User.created_at.desc())
+    if phone:
+        query = query.where(User.phone_number.contains(phone))
+    result = await db.execute(query)
+    return result.scalars().all()
+
+
+async def get_all_user_coupons(db: AsyncSession, user_id: str) -> list[UserCoupon]:
+    result = await db.execute(
+        select(UserCoupon).where(UserCoupon.user_id == user_id)
+    )
+    return result.scalars().all()
+
+
+async def adjust_points(db: AsyncSession, user_id: str, delta: int, reason: str) -> User | None:
+    """포인트 수동 증감. reason은 서버 로그에 남긴다."""
+    user = await get_user_by_id(db, user_id)
+    if user is None:
+        return None
+    user.current_points += delta
+    await db.flush()
+    logger.info(
+        "admin points adjustment: user_id=%s delta=%s reason=%s new_balance=%s",
+        user_id, delta, reason, user.current_points,
+    )
+    return user

--- a/backend/main.py
+++ b/backend/main.py
@@ -34,6 +34,9 @@ from api.cart import router as cart_router
 from api.order import router as order_router
 from api.payment import router as payment_router
 from api.user import router as user_router
+from api.admin.auth import router as admin_auth_router
+from api.admin.menu import router as admin_menu_router
+from api.admin.users import router as admin_users_router
 
 from core.db import init_db
 
@@ -64,6 +67,9 @@ app.include_router(cart_router)
 app.include_router(order_router)
 app.include_router(payment_router)
 app.include_router(user_router)
+app.include_router(admin_auth_router)
+app.include_router(admin_menu_router)
+app.include_router(admin_users_router)
 
 
 @app.get("/health")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -26,3 +26,10 @@ aiomysql>=0.2.0
 
 # AI 모듈 → 백엔드 API 호출
 httpx>=0.27.0
+
+# 관리자 인증
+# passlib(1.7.4, 2020년 이후 업데이트 없음)는 bcrypt>=4.1의 API 변경과 호환되지 않아
+# 버전을 명시적으로 고정한다(안 고정하면 비밀번호 해시 시 ValueError 발생).
+passlib[bcrypt]>=1.7.4
+bcrypt==4.0.1
+python-jose[cryptography]>=3.3.0

--- a/backend/schemas/admin_auth_schemas.py
+++ b/backend/schemas/admin_auth_schemas.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+
+
+class LoginIn(BaseModel):
+    username: str
+    password: str
+
+
+class LoginOut(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+    expires_in: int  # 초 단위
+
+
+class AdminMeOut(BaseModel):
+    id: str
+    username: str
+    display_name: str
+    role: str  # OWNER | STAFF

--- a/backend/schemas/admin_schemas.py
+++ b/backend/schemas/admin_schemas.py
@@ -1,0 +1,23 @@
+from pydantic import BaseModel
+
+from schemas.coupon_schemas import UserCouponOut
+from schemas.order_schemas import OrderAdminOut
+
+
+class UserAdminOut(BaseModel):
+    id: str
+    phone_number: str | None
+    current_points: int
+    tier: str | None
+    is_guest: bool
+    created_at: str
+
+
+class UserDetailOut(UserAdminOut):
+    recent_orders: list[OrderAdminOut]  # 최근 N건, Module E 스키마 재사용
+    coupons: list[UserCouponOut]  # 보유 쿠폰, Module F 스키마 재사용
+
+
+class PointsAdjustIn(BaseModel):
+    delta: int
+    reason: str

--- a/backend/schemas/coupon_schemas.py
+++ b/backend/schemas/coupon_schemas.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class UserCouponOut(BaseModel):
+    user_coupon_id: str
+    user_id: str
+    coupon_id: str
+    issued_at: str

--- a/backend/schemas/menu_schemas.py
+++ b/backend/schemas/menu_schemas.py
@@ -40,3 +40,63 @@ class CategoryOut(BaseModel):
 class MenuResponse(BaseModel):
     categories: list[CategoryOut]
     menu_items: dict[str, list[MenuItemOut]]  # category_slug → items
+
+
+# --- 관리자용 요청 스키마 (Module B) ---------------------------------------
+class CategoryIn(BaseModel):
+    name_ko: str
+    name_en: str
+    display_order: int = 0
+    is_visible: bool = True
+    image_url: str | None = None
+
+
+class CategoryPatchIn(BaseModel):
+    name_ko: str | None = None
+    name_en: str | None = None
+    display_order: int | None = None
+    is_visible: bool | None = None
+    image_url: str | None = None
+
+
+class MenuItemIn(BaseModel):
+    category_id: str
+    name_ko: str
+    name_en: str
+    base_price: Decimal
+    description: str = ""
+    is_available: bool = True
+    is_popular: bool = False
+    is_new: bool = False
+    display_order: int = 0
+
+
+class MenuItemPatchIn(BaseModel):
+    category_id: str | None = None
+    name_ko: str | None = None
+    name_en: str | None = None
+    base_price: Decimal | None = None
+    description: str | None = None
+    image_url: str | None = None
+    is_available: bool | None = None
+    is_popular: bool | None = None
+    is_new: bool | None = None
+    display_order: int | None = None
+
+
+class MenuOptionIn(BaseModel):
+    name_ko: str
+    name_en: str
+    description: str = ""
+    additional_price: Decimal = Decimal("0")
+    is_available: bool = True
+    display_order: int = 0
+
+
+class MenuOptionPatchIn(BaseModel):
+    name_ko: str | None = None
+    name_en: str | None = None
+    description: str | None = None
+    additional_price: Decimal | None = None
+    is_available: bool | None = None
+    display_order: int | None = None

--- a/backend/schemas/order_schemas.py
+++ b/backend/schemas/order_schemas.py
@@ -27,3 +27,19 @@ class OrderOut(BaseModel):
     points_used: int
     points_earned: int
     items: list[OrderItemOut]
+
+
+class OrderAdminOut(BaseModel):
+    order_id: str
+    order_number: str
+    order_type: str
+    status: str
+    table_number: int | None
+    subtotal: Decimal
+    discount_amount: Decimal
+    final_amount: Decimal
+    points_used: int
+    points_earned: int
+    created_at: str
+    items: list[OrderItemOut]
+    payment_status: str | None  # 연결된 Payment.status, 결제 전이면 None

--- a/database/init.sql
+++ b/database/init.sql
@@ -165,6 +165,8 @@ CREATE TABLE IF NOT EXISTS orders (
     order_number    VARCHAR(32)    NOT NULL UNIQUE,
     order_type      ENUM('EAT_IN','TAKE_OUT') NOT NULL DEFAULT 'TAKE_OUT',
     table_number    INT            NULL,
+    status          ENUM('RECEIVED','COOKING','READY','COMPLETED','CANCELLED') NOT NULL DEFAULT 'RECEIVED',
+    user_coupon_id  VARCHAR(36)    NULL,
     subtotal        DECIMAL(12, 2) NOT NULL DEFAULT 0,
     discount_amount DECIMAL(12, 2) NOT NULL DEFAULT 0,
     final_amount    DECIMAL(12, 2) NOT NULL DEFAULT 0,
@@ -172,7 +174,8 @@ CREATE TABLE IF NOT EXISTS orders (
     points_earned   INT            NOT NULL DEFAULT 0,
     created_at      DATETIME       NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT fk_orders_user FOREIGN KEY (user_id) REFERENCES users (id),
-    CONSTRAINT fk_orders_cart FOREIGN KEY (cart_id) REFERENCES carts (id)
+    CONSTRAINT fk_orders_cart FOREIGN KEY (cart_id) REFERENCES carts (id),
+    CONSTRAINT fk_orders_user_coupon FOREIGN KEY (user_coupon_id) REFERENCES user_coupons (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- 12. ORDER_ITEMS
@@ -203,6 +206,18 @@ CREATE TABLE IF NOT EXISTS payments (
     refunded_at        DATETIME       NULL,
     created_at         DATETIME       NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT fk_payments_order FOREIGN KEY (order_id) REFERENCES orders (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- 14. ADMIN_USERS
+CREATE TABLE IF NOT EXISTS admin_users (
+    id             VARCHAR(36)  NOT NULL PRIMARY KEY,
+    username       VARCHAR(64)  NOT NULL UNIQUE,
+    password_hash  VARCHAR(255) NOT NULL,
+    display_name   VARCHAR(64)  NOT NULL,
+    role           ENUM('OWNER','STAFF') NOT NULL DEFAULT 'STAFF',
+    is_active      BOOLEAN      NOT NULL DEFAULT TRUE,
+    last_login_at  DATETIME     NULL,
+    created_at     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ============================================================


### PR DESCRIPTION
- 1단계 마이그레이션: orders.status/user_coupon_id 컬럼, admin_users 테이블 추가
- Module A: JWT 기반 관리자 로그인/인증 (security.py, admin_dao.py, api/admin/auth.py)
- Module B: 카테고리·메뉴·옵션 관리자 CRUD, RAG 캐시 무효화 연동
- Module G: 회원 조회·포인트 수동 조정 API
- 메뉴/카테고리 하드 삭제 시 FK 참조로 인한 500 에러를 소프트 삭제+409로 전환