### PR TITLE
feat: 관리자 페이지 고도화 및 키오스크 할인/쿠폰 기능 개선

### DIFF
--- a/backend/api/admin/coupons.py
+++ b/backend/api/admin/coupons.py
@@ -45,3 +45,24 @@ async def issue_coupon(id: str, body: IssueReq, db: AsyncSession = Depends(get_s
         )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.patch("/{id}/toggle", response_model=CouponOut)
+async def toggle_coupon(id: str, db: AsyncSession = Depends(get_session)):
+    coupon = await coupon_dao.toggle_coupon(db, id)
+    if coupon is None:
+        raise HTTPException(status_code=404, detail="쿠폰을 찾을 수 없습니다.")
+    await db.commit()
+    await db.refresh(coupon)
+    return coupon
+
+
+@router.delete("/{id}")
+async def delete_coupon(id: str, db: AsyncSession = Depends(get_session)):
+    try:
+        await coupon_dao.delete_coupon(db, id)
+        await db.commit()
+        return {"ok": True}
+    except ValueError as e:
+        await db.commit()
+        raise HTTPException(status_code=409, detail=str(e))

--- a/backend/api/admin/discounts.py
+++ b/backend/api/admin/discounts.py
@@ -30,3 +30,22 @@ async def create_discount(body: DiscountIn, db: AsyncSession = Depends(get_sessi
     await db.commit()
     await db.refresh(discount)
     return discount
+
+
+@router.patch("/{id}/toggle", response_model=DiscountOut)
+async def toggle_discount(id: str, db: AsyncSession = Depends(get_session)):
+    discount = await discount_dao.toggle_discount(db, id)
+    if discount is None:
+        raise HTTPException(status_code=404, detail="할인을 찾을 수 없습니다.")
+    await db.commit()
+    await db.refresh(discount)
+    return discount
+
+
+@router.delete("/{id}")
+async def delete_discount(id: str, db: AsyncSession = Depends(get_session)):
+    ok = await discount_dao.delete_discount(db, id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="할인을 찾을 수 없습니다.")
+    await db.commit()
+    return {"ok": True}

--- a/backend/api/admin/menu.py
+++ b/backend/api/admin/menu.py
@@ -1,4 +1,8 @@
-from fastapi import APIRouter, Depends, HTTPException
+import os
+import uuid
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from fastapi.responses import JSONResponse
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -18,11 +22,36 @@ from schemas.menu_schemas import (
     MenuOptionPatchIn,
 )
 
+_UPLOAD_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "static", "uploads", "menu",
+)
+_ALLOWED_MIME = {"image/jpeg", "image/png", "image/webp", "image/gif"}
+_MAX_BYTES = 5 * 1024 * 1024  # 5 MB
+
 router = APIRouter(
     prefix="/api/admin",
     tags=["admin-menu"],
     dependencies=[Depends(get_current_admin)],
 )
+
+
+# --- 이미지 업로드 -----------------------------------------------------------
+@router.post("/upload/image")
+async def upload_menu_image(file: UploadFile = File(...)):
+    if file.content_type not in _ALLOWED_MIME:
+        raise HTTPException(400, "jpg, png, webp, gif 이미지만 업로드 가능합니다")
+    content = await file.read()
+    if len(content) > _MAX_BYTES:
+        raise HTTPException(400, "파일 크기는 5MB 이하여야 합니다")
+    os.makedirs(_UPLOAD_DIR, exist_ok=True)
+    ext = (file.filename or "img").rsplit(".", 1)[-1].lower()
+    if ext not in ("jpg", "jpeg", "png", "webp", "gif"):
+        ext = "jpg"
+    filename = f"{uuid.uuid4()}.{ext}"
+    with open(os.path.join(_UPLOAD_DIR, filename), "wb") as f:
+        f.write(content)
+    return {"url": f"/static/uploads/menu/{filename}"}
 
 
 # --- 카테고리 ---------------------------------------------------------------

--- a/backend/api/admin/menu.py
+++ b/backend/api/admin/menu.py
@@ -20,6 +20,7 @@ from schemas.menu_schemas import (
     MenuOptionIn,
     MenuOptionOut,
     MenuOptionPatchIn,
+    MenuResponse,
 )
 
 _UPLOAD_DIR = os.path.join(
@@ -52,6 +53,20 @@ async def upload_menu_image(file: UploadFile = File(...)):
     with open(os.path.join(_UPLOAD_DIR, filename), "wb") as f:
         f.write(content)
     return {"url": f"/static/uploads/menu/{filename}"}
+
+
+# --- 관리자용 메뉴 전체 조회 (숨김 카테고리 포함) ---------------------------
+@router.get("/menu", response_model=MenuResponse)
+async def get_admin_menu(db: AsyncSession = Depends(get_session)):
+    categories = await menu_dao.get_all_categories_admin(db)
+    menu_items: dict[str, list] = {}
+    for cat in categories:
+        items = await menu_dao.get_menu_items_by_category(db, cat.id)
+        menu_items[cat.name_en.lower()] = [MenuItemOut.model_validate(i) for i in items]
+    return MenuResponse(
+        categories=[CategoryOut.model_validate(c) for c in categories],
+        menu_items=menu_items,
+    )
 
 
 # --- 카테고리 ---------------------------------------------------------------

--- a/backend/api/admin/menu.py
+++ b/backend/api/admin/menu.py
@@ -55,13 +55,13 @@ async def upload_menu_image(file: UploadFile = File(...)):
     return {"url": f"/static/uploads/menu/{filename}"}
 
 
-# --- 관리자용 메뉴 전체 조회 (숨김 카테고리 포함) ---------------------------
+# --- 관리자용 메뉴 전체 조회 (숨김 카테고리 + 품절 메뉴 포함) --------------
 @router.get("/menu", response_model=MenuResponse)
 async def get_admin_menu(db: AsyncSession = Depends(get_session)):
     categories = await menu_dao.get_all_categories_admin(db)
     menu_items: dict[str, list] = {}
     for cat in categories:
-        items = await menu_dao.get_menu_items_by_category(db, cat.id)
+        items = await menu_dao.get_menu_items_by_category_admin(db, cat.id)
         menu_items[cat.name_en.lower()] = [MenuItemOut.model_validate(i) for i in items]
     return MenuResponse(
         categories=[CategoryOut.model_validate(c) for c in categories],

--- a/backend/api/admin/menu.py
+++ b/backend/api/admin/menu.py
@@ -212,3 +212,45 @@ async def delete_menu_option(
     await db.commit()
     invalidate_cache()
     return {"ok": True}
+
+
+# --- 세트 공통 구성 (SET_SIDE / SET_DRINK) 일괄 관리 -------------------------
+
+@router.get("/set-options")
+async def get_set_options(db: AsyncSession = Depends(get_session)):
+    """SET_SIDE / SET_DRINK 대표 옵션 목록 조회"""
+    data = await menu_dao.get_set_common_options(db)
+    def _fmt(opt):
+        return {
+            "name_ko": opt.name_ko,
+            "name_en": opt.name_en,
+            "additional_price": float(opt.additional_price),
+            "option_group": opt.option_group,
+        }
+    return {
+        "SET_SIDE":  [_fmt(o) for o in data["SET_SIDE"]],
+        "SET_DRINK": [_fmt(o) for o in data["SET_DRINK"]],
+    }
+
+
+from pydantic import BaseModel as _BaseModel
+
+class _SetOptionPatch(_BaseModel):
+    option_group: str          # SET_SIDE | SET_DRINK
+    name_ko: str
+    additional_price: float
+
+
+@router.patch("/set-options")
+async def update_set_option(payload: _SetOptionPatch, db: AsyncSession = Depends(get_session)):
+    """name_ko 기준으로 해당 그룹의 모든 옵션 additional_price 일괄 수정"""
+    if payload.option_group not in ("SET_SIDE", "SET_DRINK"):
+        raise HTTPException(400, "option_group은 SET_SIDE 또는 SET_DRINK여야 합니다")
+    count = await menu_dao.bulk_update_set_option(
+        db, payload.option_group, payload.name_ko, payload.additional_price
+    )
+    if count == 0:
+        raise HTTPException(404, f"'{payload.name_ko}' 옵션을 찾을 수 없습니다")
+    await db.commit()
+    invalidate_cache()
+    return {"ok": True, "updated": count}

--- a/backend/api/admin/stats.py
+++ b/backend/api/admin/stats.py
@@ -9,6 +9,8 @@ from schemas.stats_schemas import (
     SalesSeriesOut,
     SalesPointOut,
     PopularItemOut,
+    CategorySalesOut,
+    PaymentMethodStatsOut,
 )
 
 router = APIRouter(
@@ -42,3 +44,19 @@ async def get_popular_items(range: str = "7d", db: AsyncSession = Depends(get_se
     days = 30 if range == "30d" else 7
     items = await stats_dao.get_popular_items(db, days=days)
     return [PopularItemOut(**item) for item in items]
+
+
+@router.get("/category-sales", response_model=list[CategorySalesOut])
+async def get_category_sales(range: str = "7d", db: AsyncSession = Depends(get_session)):
+    """카테고리별 매출 비율"""
+    days = 30 if range == "30d" else 7
+    items = await stats_dao.get_category_sales(db, days=days)
+    return [CategorySalesOut(**item) for item in items]
+
+
+@router.get("/payment-methods", response_model=list[PaymentMethodStatsOut])
+async def get_payment_method_stats(range: str = "7d", db: AsyncSession = Depends(get_session)):
+    """결제수단별 건수 및 합계"""
+    days = 30 if range == "30d" else 7
+    items = await stats_dao.get_payment_method_stats(db, days=days)
+    return [PaymentMethodStatsOut(**item) for item in items]

--- a/backend/api/admin/users.py
+++ b/backend/api/admin/users.py
@@ -4,7 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from core.db import get_session
 from core.security import get_current_admin
 from dao import order_dao, user_dao
-from schemas.admin_schemas import PointsAdjustIn, UserAdminOut, UserDetailOut
+from schemas.admin_schemas import PointsAdjustIn, TierUpdateIn, UserAdminOut, UserDetailOut
 from schemas.coupon_schemas import UserCouponOut
 from schemas.order_schemas import OrderAdminOut, OrderItemOut
 
@@ -106,3 +106,21 @@ async def adjust_user_points(
 
     membership = await user_dao.get_membership(db, user.id)
     return _to_user_admin_out(user, membership.tier if membership else None)
+
+
+@router.patch("/{user_id}/tier", response_model=UserAdminOut)
+async def update_user_tier(
+    user_id: str, payload: TierUpdateIn, db: AsyncSession = Depends(get_session)
+):
+    if payload.tier not in user_dao.VALID_TIERS:
+        raise HTTPException(400, f"유효하지 않은 등급입니다. ({', '.join(sorted(user_dao.VALID_TIERS))})")
+
+    user = await user_dao.get_user_by_id(db, user_id)
+    if user is None:
+        raise HTTPException(404, "등록된 회원이 아닙니다")
+    if user.is_guest:
+        raise HTTPException(400, "비회원에게는 등급을 부여할 수 없습니다")
+
+    membership = await user_dao.update_user_tier(db, user_id, payload.tier)
+    await db.commit()
+    return _to_user_admin_out(user, membership.tier)

--- a/backend/api/order.py
+++ b/backend/api/order.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, date as _date
 from decimal import Decimal
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import func, select as sa_select
@@ -40,6 +40,63 @@ async def validate_coupon(code: str, subtotal: Decimal, db: AsyncSession = Depen
         "valid": True,
         "discount_amount": discount_amount,
         "final_amount": max(Decimal("0"), subtotal - discount_amount),
+    }
+
+
+@router.get("/preview-discount")
+async def preview_discount(session_id: str, db: AsyncSession = Depends(get_session)):
+    """장바구니 기준으로 적용 가능한 할인 금액을 미리 계산해 반환한다 (주문 생성 없음)."""
+    cart = await cart_dao.get_cart_with_items(db, session_id)
+    if not cart or not cart.items:
+        return {"discount_amount": 0.0, "final_amount": 0.0, "applicable": []}
+
+    subtotal = sum(item.unit_price * item.quantity for item in cart.items)
+    discount_amount = Decimal("0")
+    applicable = []
+
+    active_discounts = await discount_dao.get_active_discounts(db)
+    today = _date.today()
+    for disc in active_discounts:
+        if disc.applicable_tier != "ALL":
+            continue
+        if disc.valid_from and today < disc.valid_from:
+            continue
+        if disc.valid_until and today > disc.valid_until:
+            continue
+
+        if disc.target_type == "ALL":
+            base = subtotal
+        elif disc.target_type == "CATEGORY":
+            base = sum(
+                item.unit_price * item.quantity
+                for item in cart.items
+                if item.menu_item and item.menu_item.category_id == disc.category_id
+            )
+        elif disc.target_type == "MENU":
+            base = sum(
+                item.unit_price * item.quantity
+                for item in cart.items
+                if item.menu_item_id == disc.menu_item_id
+            )
+        else:
+            continue
+
+        if base <= 0:
+            continue
+
+        if disc.discount_type == "PERCENT":
+            d = base * disc.discount_value / Decimal("100")
+        else:
+            d = min(Decimal(str(disc.discount_value)), base)
+
+        discount_amount += d
+        applicable.append({"name": disc.name_ko, "amount": float(d)})
+
+    discount_amount = min(discount_amount, subtotal)
+    return {
+        "discount_amount": float(discount_amount),
+        "final_amount": float(subtotal - discount_amount),
+        "applicable": applicable,
     }
 
 

--- a/backend/api/order.py
+++ b/backend/api/order.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from core.db import get_session
 from core.models import Order, OrderItem
 from schemas.order_schemas import OrderIn, OrderOut, OrderItemOut
-from dao import user_dao, order_dao, cart_dao
+from dao import user_dao, order_dao, cart_dao, discount_dao
 
 router = APIRouter(prefix="/api/orders", tags=["orders"])
 
@@ -81,6 +81,45 @@ async def create_order(body: OrderIn, db: AsyncSession = Depends(get_session)):
         else:
             discount_amount = coupon.discount_value
         user_coupon_id = user_coupon.id
+
+    # 4.5. Discount 테이블 할인 적용 (ALL / CATEGORY / MENU, applicable_tier=ALL만)
+    from datetime import date as _date
+    active_discounts = await discount_dao.get_active_discounts(db)
+    today = _date.today()
+    for disc in active_discounts:
+        if disc.applicable_tier != "ALL":
+            continue
+        if disc.valid_from and today < disc.valid_from:
+            continue
+        if disc.valid_until and today > disc.valid_until:
+            continue
+
+        if disc.target_type == "ALL":
+            base = subtotal
+        elif disc.target_type == "CATEGORY":
+            base = sum(
+                item.unit_price * item.quantity
+                for item in cart.items
+                if item.menu_item and item.menu_item.category_id == disc.category_id
+            )
+        elif disc.target_type == "MENU":
+            base = sum(
+                item.unit_price * item.quantity
+                for item in cart.items
+                if item.menu_item_id == disc.menu_item_id
+            )
+        else:
+            continue
+
+        if base <= 0:
+            continue
+
+        if disc.discount_type == "PERCENT":
+            discount_amount += base * disc.discount_value / Decimal("100")
+        else:
+            discount_amount += min(Decimal(str(disc.discount_value)), base)
+
+    discount_amount = min(discount_amount, subtotal)
 
     # 5. 포인트 사용 및 적립 계산 (결제금액의 5% 적립)
     points_to_use = body.points_to_use or 0

--- a/backend/api/order.py
+++ b/backend/api/order.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from core.db import get_session
 from core.models import Order, OrderItem
 from schemas.order_schemas import OrderIn, OrderOut, OrderItemOut
+from schemas.coupon_schemas import DiscountOut
 from dao import user_dao, order_dao, cart_dao, discount_dao
 
 router = APIRouter(prefix="/api/orders", tags=["orders"])
@@ -22,6 +23,12 @@ def _to_order_item_out(item: OrderItem) -> OrderItemOut:
         selected_options=item.selected_options or [],
         special_note=item.special_note,
     )
+
+
+@router.get("/active-discounts", response_model=list[DiscountOut])
+async def get_active_discounts_public(db: AsyncSession = Depends(get_session)):
+    """현재 활성화된 할인 목록 (인증 불필요, 키오스크 화면용)."""
+    return await discount_dao.get_active_discounts(db)
 
 
 @router.get("/validate-coupon")

--- a/backend/dao/coupon_dao.py
+++ b/backend/dao/coupon_dao.py
@@ -1,7 +1,7 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func
-from backend.core.models import Coupon, UserCoupon, User
-from backend.schemas.coupon_schemas import CouponIn
+from core.models import Coupon, UserCoupon, User
+from schemas.coupon_schemas import CouponIn
 
 
 async def list_coupons(db: AsyncSession) -> list[Coupon]:

--- a/backend/dao/coupon_dao.py
+++ b/backend/dao/coupon_dao.py
@@ -1,5 +1,5 @@
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select
+from sqlalchemy import select, func
 from backend.core.models import Coupon, UserCoupon, User
 from backend.schemas.coupon_schemas import CouponIn
 
@@ -12,6 +12,31 @@ async def list_coupons(db: AsyncSession) -> list[Coupon]:
 async def create_coupon(db: AsyncSession, data: CouponIn) -> Coupon:
     coupon = Coupon(**data.model_dump())
     db.add(coupon)
+    await db.flush()
+    return coupon
+
+
+async def toggle_coupon(db: AsyncSession, coupon_id: str) -> Coupon | None:
+    coupon = await db.get(Coupon, coupon_id)
+    if coupon is None:
+        return None
+    coupon.is_active = not coupon.is_active
+    await db.flush()
+    return coupon
+
+
+async def delete_coupon(db: AsyncSession, coupon_id: str) -> Coupon | None:
+    coupon = await db.get(Coupon, coupon_id)
+    if coupon is None:
+        return None
+    count_result = await db.execute(
+        select(func.count()).where(UserCoupon.coupon_id == coupon_id)
+    )
+    if count_result.scalar() > 0:
+        coupon.is_active = False
+        await db.flush()
+        raise ValueError("이미 발급된 쿠폰이 있어 삭제할 수 없습니다. 비활성화 처리했습니다.")
+    await db.delete(coupon)
     await db.flush()
     return coupon
 

--- a/backend/dao/discount_dao.py
+++ b/backend/dao/discount_dao.py
@@ -14,3 +14,21 @@ async def create_discount(db: AsyncSession, data: DiscountIn) -> Discount:
     db.add(discount)
     await db.flush()
     return discount
+
+
+async def toggle_discount(db: AsyncSession, discount_id: str) -> Discount | None:
+    discount = await db.get(Discount, discount_id)
+    if discount is None:
+        return None
+    discount.is_active = not discount.is_active
+    await db.flush()
+    return discount
+
+
+async def delete_discount(db: AsyncSession, discount_id: str) -> bool:
+    discount = await db.get(Discount, discount_id)
+    if discount is None:
+        return False
+    await db.delete(discount)
+    await db.flush()
+    return True

--- a/backend/dao/discount_dao.py
+++ b/backend/dao/discount_dao.py
@@ -1,11 +1,17 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
-from backend.core.models import Discount
-from backend.schemas.coupon_schemas import DiscountIn
+from core.models import Discount
+from schemas.coupon_schemas import DiscountIn
 
 
 async def list_discounts(db: AsyncSession) -> list[Discount]:
     result = await db.execute(select(Discount))
+    return result.scalars().all()
+
+
+async def get_active_discounts(db: AsyncSession) -> list[Discount]:
+    """현재 활성화된 할인 목록 (주문 계산에 사용)"""
+    result = await db.execute(select(Discount).where(Discount.is_active == True))
     return result.scalars().all()
 
 

--- a/backend/dao/menu_dao.py
+++ b/backend/dao/menu_dao.py
@@ -169,3 +169,47 @@ async def update_menu_option(db: AsyncSession, option: MenuOption, data: dict) -
 async def delete_menu_option(db: AsyncSession, option: MenuOption) -> None:
     await db.delete(option)
     await db.flush()
+
+
+# ── 세트 공통 구성 (SET_SIDE / SET_DRINK) ─────────────────────────────────
+
+async def get_set_common_options(db: AsyncSession) -> dict[str, list]:
+    """
+    SET_SIDE / SET_DRINK 그룹의 '대표' 옵션 목록을 반환한다.
+    동일 name_ko 기준 첫 번째 레코드를 대표값으로 사용한다.
+    반환 형태: {"SET_SIDE": [...], "SET_DRINK": [...]}
+    """
+    from sqlalchemy import or_
+    result = await db.execute(
+        select(MenuOption)
+        .where(or_(MenuOption.option_group == "SET_SIDE", MenuOption.option_group == "SET_DRINK"))
+        .order_by(MenuOption.option_group, MenuOption.display_order)
+    )
+    options = result.scalars().all()
+
+    seen: dict[str, set] = {"SET_SIDE": set(), "SET_DRINK": set()}
+    out:  dict[str, list] = {"SET_SIDE": [],    "SET_DRINK": []}
+    for opt in options:
+        grp = opt.option_group
+        if opt.name_ko not in seen[grp]:
+            seen[grp].add(opt.name_ko)
+            out[grp].append(opt)
+    return out
+
+
+async def bulk_update_set_option(
+    db: AsyncSession, group: str, name_ko: str, additional_price: float
+) -> int:
+    """
+    같은 그룹(SET_SIDE / SET_DRINK) + name_ko를 가진 모든 MenuOption의
+    additional_price를 일괄 수정한다. 수정된 행 수를 반환한다.
+    """
+    from sqlalchemy import update as sa_update
+    from decimal import Decimal
+    result = await db.execute(
+        sa_update(MenuOption)
+        .where(MenuOption.option_group == group)
+        .where(MenuOption.name_ko == name_ko)
+        .values(additional_price=Decimal(str(additional_price)))
+    )
+    return result.rowcount

--- a/backend/dao/menu_dao.py
+++ b/backend/dao/menu_dao.py
@@ -58,6 +58,19 @@ async def get_all_categories_admin(db: AsyncSession) -> list[Category]:
     return result.scalars().all()
 
 
+async def get_menu_items_by_category_admin(
+    db: AsyncSession, category_id: str
+) -> list[MenuItem]:
+    """관리자용 - 품절(is_available=False) 메뉴도 포함"""
+    result = await db.execute(
+        select(MenuItem)
+        .where(MenuItem.category_id == category_id)
+        .options(*_MENU_ITEM_LOAD_OPTS)
+        .order_by(MenuItem.display_order)
+    )
+    return result.scalars().all()
+
+
 async def get_category_by_id(db: AsyncSession, category_id: str) -> Category | None:
     result = await db.execute(select(Category).where(Category.id == category_id))
     return result.scalar_one_or_none()

--- a/backend/dao/stats_dao.py
+++ b/backend/dao/stats_dao.py
@@ -1,7 +1,7 @@
 from datetime import date, timedelta
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
-from backend.core.models import Order, OrderItem, MenuItem, Category, Payment
+from core.models import Order, OrderItem, MenuItem, Category, Payment
 
 
 async def get_today_summary(db: AsyncSession) -> dict:

--- a/backend/dao/stats_dao.py
+++ b/backend/dao/stats_dao.py
@@ -1,7 +1,7 @@
 from datetime import date, timedelta
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
-from backend.core.models import Order, OrderItem, MenuItem
+from backend.core.models import Order, OrderItem, MenuItem, Category, Payment
 
 
 async def get_today_summary(db: AsyncSession) -> dict:
@@ -81,6 +81,68 @@ async def get_popular_items(db: AsyncSession, days: int, limit: int = 5) -> list
             "name_ko": r.name_ko,
             "quantity_sold": int(r.quantity_sold),
             "revenue": float(r.revenue),
+        }
+        for r in result.all()
+    ]
+
+
+async def get_category_sales(db: AsyncSession, days: int) -> list[dict]:
+    """카테고리별 매출 비율"""
+    start_date = date.today() - timedelta(days=days)
+    result = await db.execute(
+        select(
+            Category.id,
+            Category.name_ko,
+            func.sum(OrderItem.total_price).label("revenue"),
+            func.sum(OrderItem.quantity).label("quantity_sold"),
+        )
+        .join(Order, OrderItem.order_id == Order.id)
+        .join(MenuItem, OrderItem.menu_item_id == MenuItem.id)
+        .join(Category, MenuItem.category_id == Category.id)
+        .where(
+            Order.status == "COMPLETED",
+            func.date(Order.created_at) >= start_date,
+        )
+        .group_by(Category.id, Category.name_ko)
+        .order_by(func.sum(OrderItem.total_price).desc())
+    )
+    rows = result.all()
+    total_revenue = sum(float(r.revenue) for r in rows) or 1.0
+    return [
+        {
+            "category_id": r.id,
+            "name_ko": r.name_ko,
+            "revenue": float(r.revenue),
+            "quantity_sold": int(r.quantity_sold),
+            "ratio": round(float(r.revenue) / total_revenue * 100, 1),
+        }
+        for r in rows
+    ]
+
+
+async def get_payment_method_stats(db: AsyncSession, days: int) -> list[dict]:
+    """결제수단별 건수 및 합계"""
+    start_date = date.today() - timedelta(days=days)
+    result = await db.execute(
+        select(
+            Payment.method,
+            func.count(Payment.id).label("count"),
+            func.sum(Payment.amount).label("total_amount"),
+        )
+        .join(Order, Payment.order_id == Order.id)
+        .where(
+            Payment.status == "SUCCESS",
+            Order.status == "COMPLETED",
+            func.date(Order.created_at) >= start_date,
+        )
+        .group_by(Payment.method)
+        .order_by(func.sum(Payment.amount).desc())
+    )
+    return [
+        {
+            "method": r.method,
+            "count": int(r.count),
+            "total_amount": float(r.total_amount),
         }
         for r in result.all()
     ]

--- a/backend/dao/user_dao.py
+++ b/backend/dao/user_dao.py
@@ -197,6 +197,20 @@ async def get_user_coupon_by_code(db: AsyncSession, user_id: str, code: str) -> 
     return result.scalar_one_or_none()
 
 
+VALID_TIERS = {"BASIC", "SILVER", "GOLD"}
+
+
+async def update_user_tier(db: AsyncSession, user_id: str, tier: str) -> Membership:
+    membership = await get_membership(db, user_id)
+    if membership is None:
+        membership = Membership(user_id=user_id, tier=tier)
+        db.add(membership)
+    else:
+        membership.tier = tier
+    await db.flush()
+    return membership
+
+
 async def mark_coupon_used(db: AsyncSession, user_coupon_id: str) -> None:
     """쿠폰 사용 완료 처리. is_used=True, used_at=now(), coupons.used_count += 1."""
     user_coupon = await db.get(UserCoupon, user_coupon_id)

--- a/backend/main.py
+++ b/backend/main.py
@@ -15,6 +15,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 
 # 제스처/수집 라우터는 mediapipe 의존 — 환경에 따라 로드 실패할 수 있으므로 가드.
 try:
@@ -84,6 +85,11 @@ app.include_router(admin_coupons_router)
 app.include_router(admin_discounts_router)
 app.include_router(admin_payments_router)
 app.include_router(admin_stats_router)
+
+
+_static_dir = os.path.join(os.path.dirname(__file__), "static")
+os.makedirs(_static_dir, exist_ok=True)
+app.mount("/static", StaticFiles(directory=_static_dir), name="static")
 
 
 @app.get("/health")

--- a/backend/schemas/admin_schemas.py
+++ b/backend/schemas/admin_schemas.py
@@ -21,3 +21,7 @@ class UserDetailOut(UserAdminOut):
 class PointsAdjustIn(BaseModel):
     delta: int
     reason: str
+
+
+class TierUpdateIn(BaseModel):
+    tier: str  # BASIC | SILVER | GOLD

--- a/backend/schemas/menu_schemas.py
+++ b/backend/schemas/menu_schemas.py
@@ -104,6 +104,7 @@ class MenuOptionIn(BaseModel):
     additional_price: Decimal = Decimal("0")
     is_available: bool = True
     display_order: int = 0
+    option_group: str = "EXCLUDE"  # SET_UPGRADE | EXCLUDE | SET_SIDE | SET_DRINK
 
 
 class MenuOptionPatchIn(BaseModel):
@@ -113,3 +114,4 @@ class MenuOptionPatchIn(BaseModel):
     additional_price: Decimal | None = None
     is_available: bool | None = None
     display_order: int | None = None
+    option_group: str | None = None

--- a/backend/schemas/menu_schemas.py
+++ b/backend/schemas/menu_schemas.py
@@ -21,6 +21,7 @@ class AllergenOut(BaseModel):
 
 class MenuItemOut(BaseModel):
     id: str
+    category_id: str
     name_ko: str
     name_en: str
     base_price: Decimal

--- a/backend/schemas/stats_schemas.py
+++ b/backend/schemas/stats_schemas.py
@@ -24,4 +24,17 @@ class PopularItemOut(BaseModel):
     name_ko: str
     quantity_sold: int
     revenue: float
-    
+
+
+class CategorySalesOut(BaseModel):
+    category_id: str
+    name_ko: str
+    revenue: float
+    quantity_sold: int
+    ratio: float
+
+
+class PaymentMethodStatsOut(BaseModel):
+    method: str
+    count: int
+    total_amount: float

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>F BURGER 관리자</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" />
+  </head>
+  <body>
+    <div id="admin-root"></div>
+    <script type="module" src="/src/admin-main.jsx"></script>
+  </body>
+</html>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -62,6 +62,7 @@ function adaptCartItem(ci, menuById) {
   return {
     cartId: ci.cart_item_id,
     id: ci.menu_item_id,
+    categoryId: menu?.categoryId ?? null,
     name: menu?.name ?? ci.name_ko,
     image: isSet ? (menu?.setImage ?? menu?.image) : menu?.image,
     type: isSet ? 'set' : 'single',

--- a/frontend/src/admin-main.jsx
+++ b/frontend/src/admin-main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import AdminApp from './admin/AdminApp.jsx'
+import './admin/admin.css'
+
+ReactDOM.createRoot(document.getElementById('admin-root')).render(
+  <React.StrictMode>
+    <AdminApp />
+  </React.StrictMode>
+)

--- a/frontend/src/admin/AdminApp.jsx
+++ b/frontend/src/admin/AdminApp.jsx
@@ -1,0 +1,73 @@
+import { useState, useEffect } from 'react'
+import { login, getMe, logout } from './api/adminApi.js'
+import Layout from './components/Layout.jsx'
+import LoginPage from './pages/LoginPage.jsx'
+import DashboardPage from './pages/DashboardPage.jsx'
+import OrdersPage from './pages/OrdersPage.jsx'
+import PaymentsPage from './pages/PaymentsPage.jsx'
+import MenuPage from './pages/MenuPage.jsx'
+import CouponsPage from './pages/CouponsPage.jsx'
+import UsersPage from './pages/UsersPage.jsx'
+
+const PAGES = {
+  dashboard: { label: '대시보드',  Component: DashboardPage },
+  orders:    { label: '주문 관리', Component: OrdersPage    },
+  payments:  { label: '결제·환불', Component: PaymentsPage  },
+  menu:      { label: '메뉴 관리', Component: MenuPage      },
+  coupons:   { label: '쿠폰·할인', Component: CouponsPage   },
+  users:     { label: '회원 관리', Component: UsersPage     },
+}
+
+export default function AdminApp() {
+  const [admin, setAdmin] = useState(null)
+  const [page, setPage] = useState('dashboard')
+  const [checking, setChecking] = useState(true)
+
+  useEffect(() => {
+    const token = localStorage.getItem('admin_token')
+    if (!token) { setChecking(false); return }
+    getMe()
+      .then(me => setAdmin(me))
+      .catch(() => localStorage.removeItem('admin_token'))
+      .finally(() => setChecking(false))
+  }, [])
+
+  const handleLogin = async (username, password) => {
+    const data = await login(username, password)
+    localStorage.setItem('admin_token', data.access_token)
+    const me = await getMe()
+    setAdmin(me)
+  }
+
+  const handleLogout = async () => {
+    await logout()
+    setAdmin(null)
+    setPage('dashboard')
+  }
+
+  if (checking) {
+    return (
+      <div style={{ display:'flex', alignItems:'center', justifyContent:'center', height:'100vh', color:'#aaa', fontFamily:'Pretendard,sans-serif' }}>
+        로딩 중…
+      </div>
+    )
+  }
+
+  if (!admin) {
+    return <LoginPage onLogin={handleLogin} />
+  }
+
+  const PageComponent = PAGES[page]?.Component ?? DashboardPage
+
+  return (
+    <Layout
+      admin={admin}
+      currentPage={page}
+      pages={PAGES}
+      onNavigate={setPage}
+      onLogout={handleLogout}
+    >
+      <PageComponent />
+    </Layout>
+  )
+}

--- a/frontend/src/admin/admin.css
+++ b/frontend/src/admin/admin.css
@@ -30,18 +30,15 @@ input, select, textarea { font-family: inherit; }
 .sidebar-logo {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 20px 20px 18px;
-  color: #F5B800;
-  font-size: 18px;
-  font-weight: 700;
-  letter-spacing: 0.5px;
+  justify-content: center;
+  padding: 18px 16px 16px;
   border-bottom: 1px solid rgba(255,255,255,0.1);
 }
 
-.sidebar-logo-icon {
-  font-size: 24px;
-  line-height: 1;
+.sidebar-logo img {
+  max-width: 100%;
+  height: 44px;
+  object-fit: contain;
 }
 
 .sidebar-nav {

--- a/frontend/src/admin/admin.css
+++ b/frontend/src/admin/admin.css
@@ -1,0 +1,449 @@
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: 'Pretendard', -apple-system, BlinkMacSystemFont, sans-serif;
+  background: #f5f5f5;
+  color: #222;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+button { font-family: inherit; cursor: pointer; }
+input, select, textarea { font-family: inherit; }
+
+/* ── Layout ─────────────────────────────────────────── */
+.admin-layout {
+  display: flex;
+  min-height: 100vh;
+}
+
+/* ── Sidebar ─────────────────────────────────────────── */
+.sidebar {
+  width: 200px;
+  min-width: 200px;
+  background: #744032;
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+}
+
+.sidebar-logo {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 20px 20px 18px;
+  color: #F5B800;
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid rgba(255,255,255,0.1);
+}
+
+.sidebar-logo-icon {
+  font-size: 24px;
+  line-height: 1;
+}
+
+.sidebar-nav {
+  padding: 12px 0;
+  flex: 1;
+}
+
+.sidebar-nav-item {
+  display: block;
+  padding: 13px 20px;
+  color: rgba(255,255,255,0.75);
+  font-size: 15px;
+  font-weight: 500;
+  cursor: pointer;
+  border-left: 4px solid transparent;
+  transition: background 0.15s, color 0.15s;
+  user-select: none;
+}
+
+.sidebar-nav-item:hover {
+  background: rgba(255,255,255,0.08);
+  color: #fff;
+}
+
+.sidebar-nav-item.active {
+  border-left-color: #F5B800;
+  background: rgba(255,255,255,0.08);
+  color: #fff;
+  font-weight: 600;
+}
+
+/* ── Main ─────────────────────────────────────────────── */
+.admin-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+}
+
+/* ── Header ──────────────────────────────────────────── */
+.admin-header {
+  height: 56px;
+  background: #fff;
+  border-bottom: 1px solid #e8e8e8;
+  display: flex;
+  align-items: center;
+  padding: 0 28px;
+  flex-shrink: 0;
+}
+
+.admin-header-title {
+  font-size: 20px;
+  font-weight: 700;
+  color: #222;
+  flex: 1;
+}
+
+.admin-header-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.admin-header-user-label {
+  font-size: 13px;
+  color: #888;
+}
+
+.admin-role-badge {
+  background: #744032;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 700;
+  padding: 3px 10px;
+  border-radius: 20px;
+}
+
+.btn-logout {
+  background: none;
+  border: 1.5px solid #bbb;
+  border-radius: 6px;
+  padding: 5px 14px;
+  font-size: 13px;
+  color: #444;
+  font-weight: 500;
+}
+
+.btn-logout:hover { border-color: #744032; color: #744032; }
+
+/* ── Content ──────────────────────────────────────────── */
+.admin-content {
+  flex: 1;
+  padding: 28px;
+  overflow-y: auto;
+}
+
+/* ── Cards ───────────────────────────────────────────── */
+.card {
+  background: #fff;
+  border-radius: 12px;
+  padding: 20px 24px;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.07);
+}
+
+/* ── Filter Chips ────────────────────────────────────── */
+.filter-chips {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.chip {
+  padding: 6px 16px;
+  border-radius: 999px;
+  border: 1.5px solid #ddd;
+  background: #fff;
+  font-size: 13px;
+  color: #555;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.12s;
+}
+
+.chip:hover { border-color: #744032; color: #744032; }
+
+.chip.active {
+  background: #744032;
+  border-color: #744032;
+  color: #fff;
+}
+
+/* ── Table ───────────────────────────────────────────── */
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.data-table th {
+  text-align: left;
+  padding: 10px 12px;
+  color: #888;
+  font-weight: 500;
+  border-bottom: 1px solid #eee;
+  white-space: nowrap;
+}
+
+.data-table td {
+  padding: 12px 12px;
+  border-bottom: 1px solid #f0f0f0;
+  vertical-align: middle;
+}
+
+.data-table tbody tr:hover { background: #fafafa; }
+.data-table tbody tr.selected { background: #fff5f0; }
+
+.order-number {
+  color: #e00;
+  font-weight: 700;
+}
+
+/* ── Status Badges ───────────────────────────────────── */
+.badge {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+/* Order status */
+.badge-received    { background: #e8f5ef; color: #1b8a6e; }
+.badge-cooking     { background: #fff4d4; color: #b87800; }
+.badge-ready       { background: #e3f0ff; color: #2666c7; }
+.badge-completed   { background: #f0f0f0; color: #777; }
+.badge-cancelled   { background: #fde8e8; color: #c0392b; }
+
+/* Payment status */
+.badge-success     { background: #e6f4ea; color: #2e7d32; }
+.badge-pending     { background: #f5f5f5; color: #888; }
+.badge-failed      { background: #fde8e8; color: #c0392b; }
+.badge-refunded    { background: #f0f0f0; color: #777; }
+
+/* Toggle/active tags */
+.badge-active      { background: #e6f4ea; color: #2e7d32; }
+.badge-inactive    { background: #f0f0f0; color: #999; }
+
+/* ── Buttons ─────────────────────────────────────────── */
+.btn-primary {
+  background: #744032;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 18px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s;
+}
+
+.btn-primary:hover { background: #5e3329; }
+
+.btn-yellow {
+  background: #F5B800;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 18px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.btn-yellow:hover { background: #d9a200; }
+
+.btn-outline {
+  background: #fff;
+  color: #744032;
+  border: 1.5px solid #744032;
+  border-radius: 8px;
+  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.12s;
+}
+
+.btn-outline:hover { background: #744032; color: #fff; }
+
+.btn-danger {
+  background: #c0392b;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.btn-danger:hover { background: #a93226; }
+
+.btn-sm {
+  padding: 4px 12px;
+  font-size: 12px;
+  border-radius: 6px;
+}
+
+.btn-disabled {
+  background: #f0f0f0;
+  color: #bbb;
+  border: none;
+  border-radius: 8px;
+  padding: 6px 14px;
+  font-size: 13px;
+  cursor: not-allowed;
+}
+
+/* ── Toggle switch ────────────────────────────────────── */
+.toggle {
+  position: relative;
+  width: 40px;
+  height: 22px;
+  cursor: pointer;
+}
+
+.toggle input { display: none; }
+
+.toggle-track {
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+  background: #ddd;
+  transition: background 0.2s;
+}
+
+.toggle input:checked + .toggle-track { background: #F5B800; }
+
+.toggle-thumb {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform 0.2s;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+}
+
+.toggle input:checked ~ .toggle-thumb { transform: translateX(18px); }
+
+/* ── Forms ───────────────────────────────────────────── */
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 16px;
+}
+
+.form-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: #555;
+}
+
+.form-input {
+  border: 1.5px solid #ddd;
+  border-radius: 8px;
+  padding: 10px 14px;
+  font-size: 14px;
+  outline: none;
+  transition: border-color 0.15s;
+  width: 100%;
+}
+
+.form-input:focus { border-color: #744032; }
+
+/* ── Modal ───────────────────────────────────────────── */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-box {
+  background: #fff;
+  border-radius: 14px;
+  padding: 28px;
+  width: 420px;
+  max-width: 95vw;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.15);
+}
+
+.modal-title {
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 20px;
+  color: #222;
+}
+
+.modal-footer {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  margin-top: 24px;
+}
+
+/* ── Detail panel ────────────────────────────────────── */
+.detail-panel {
+  width: 340px;
+  min-width: 340px;
+  background: #fff;
+  border-radius: 12px;
+  padding: 20px;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.07);
+  position: relative;
+  overflow-y: auto;
+  max-height: calc(100vh - 200px);
+}
+
+.detail-panel-close {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  background: none;
+  border: none;
+  font-size: 18px;
+  color: #aaa;
+  cursor: pointer;
+  line-height: 1;
+  padding: 4px;
+}
+
+.detail-panel-close:hover { color: #555; }
+
+/* ── Misc ────────────────────────────────────────────── */
+.text-red { color: #e00; }
+.text-muted { color: #999; font-size: 13px; }
+.text-bold { font-weight: 700; }
+.flex { display: flex; }
+.flex-center { display: flex; align-items: center; }
+.gap-8 { gap: 8px; }
+.gap-12 { gap: 12px; }
+.flex-between { display: flex; align-items: center; justify-content: space-between; }
+
+.divider { height: 1px; background: #f0f0f0; margin: 16px 0; }
+
+/* Loading / empty state */
+.loading-text {
+  text-align: center;
+  color: #aaa;
+  padding: 40px 0;
+  font-size: 14px;
+}

--- a/frontend/src/admin/admin.css
+++ b/frontend/src/admin/admin.css
@@ -324,7 +324,8 @@ input, select, textarea { font-family: inherit; }
   transition: background 0.2s;
 }
 
-.toggle input:checked + .toggle-track { background: #F5B800; }
+.toggle input:checked + .toggle-track,
+.toggle.checked .toggle-track { background: #744032; }
 
 .toggle-thumb {
   position: absolute;
@@ -338,7 +339,8 @@ input, select, textarea { font-family: inherit; }
   box-shadow: 0 1px 3px rgba(0,0,0,0.2);
 }
 
-.toggle input:checked ~ .toggle-thumb { transform: translateX(18px); }
+.toggle input:checked ~ .toggle-thumb,
+.toggle.checked .toggle-thumb { transform: translateX(18px); }
 
 /* ── Forms ───────────────────────────────────────────── */
 .form-group {

--- a/frontend/src/admin/api/adminApi.js
+++ b/frontend/src/admin/api/adminApi.js
@@ -119,7 +119,62 @@ export async function adjustPoints(id, delta, reason) {
   return req('PATCH', `/api/admin/users/${id}/points`, { delta, reason })
 }
 
-// ── Orders (Dummy) ───────────────────────────────────
+// ── Orders (Real API) ────────────────────────────────
+export async function fetchAdminOrders(status) {
+  const q = status ? `?status=${encodeURIComponent(status)}` : ''
+  return req('GET', `/api/admin/orders${q}`)
+}
+
+export async function updateOrderStatus(orderId, status) {
+  return req('PATCH', `/api/admin/orders/${orderId}/status?status=${encodeURIComponent(status)}`)
+}
+
+// ── Payments (Real API) ───────────────────────────────
+export async function fetchAdminPayments(status) {
+  const q = status ? `?status=${encodeURIComponent(status)}` : ''
+  return req('GET', `/api/admin/payments${q}`)
+}
+
+export async function refundPayment(id, reason) {
+  return req('POST', `/api/admin/payments/${id}/refund`, { reason })
+}
+
+// ── Stats (Real API) ─────────────────────────────────
+export async function fetchStatsSummary() {
+  return req('GET', '/api/admin/stats/summary')
+}
+
+export async function fetchSalesSeries(range = '7d') {
+  return req('GET', `/api/admin/stats/sales?range=${range}`)
+}
+
+export async function fetchPopularItems(range = '7d') {
+  return req('GET', `/api/admin/stats/popular-items?range=${range}`)
+}
+
+// ── Coupons (Real API) ────────────────────────────────
+export async function fetchAdminCoupons() {
+  return req('GET', '/api/admin/coupons')
+}
+
+export async function createCoupon(payload) {
+  return req('POST', '/api/admin/coupons', payload)
+}
+
+export async function issueCoupon(couponId, phone) {
+  return req('POST', `/api/admin/coupons/${couponId}/issue`, { phone })
+}
+
+// ── Discounts (Real API) ──────────────────────────────
+export async function fetchAdminDiscounts() {
+  return req('GET', '/api/admin/discounts')
+}
+
+export async function createDiscount(payload) {
+  return req('POST', '/api/admin/discounts', payload)
+}
+
+// ── Legacy dummy stubs (하위호환) ──────────────────────
 const now = new Date()
 function t(h, m) {
   const d = new Date(now)

--- a/frontend/src/admin/api/adminApi.js
+++ b/frontend/src/admin/api/adminApi.js
@@ -119,6 +119,10 @@ export async function adjustPoints(id, delta, reason) {
   return req('PATCH', `/api/admin/users/${id}/points`, { delta, reason })
 }
 
+export async function updateUserTier(id, tier) {
+  return req('PATCH', `/api/admin/users/${id}/tier`, { tier })
+}
+
 // ── Orders (Real API) ────────────────────────────────
 export async function fetchAdminOrders(status) {
   const q = status ? `?status=${encodeURIComponent(status)}` : ''
@@ -152,6 +156,14 @@ export async function fetchPopularItems(range = '7d') {
   return req('GET', `/api/admin/stats/popular-items?range=${range}`)
 }
 
+export async function fetchCategorySales(range = '7d') {
+  return req('GET', `/api/admin/stats/category-sales?range=${range}`)
+}
+
+export async function fetchPaymentMethodStats(range = '7d') {
+  return req('GET', `/api/admin/stats/payment-methods?range=${range}`)
+}
+
 // ── Coupons (Real API) ────────────────────────────────
 export async function fetchAdminCoupons() {
   return req('GET', '/api/admin/coupons')
@@ -165,6 +177,14 @@ export async function issueCoupon(couponId, phone) {
   return req('POST', `/api/admin/coupons/${couponId}/issue`, { phone })
 }
 
+export async function toggleCoupon(id) {
+  return req('PATCH', `/api/admin/coupons/${id}/toggle`)
+}
+
+export async function deleteCoupon(id) {
+  return req('DELETE', `/api/admin/coupons/${id}`)
+}
+
 // ── Discounts (Real API) ──────────────────────────────
 export async function fetchAdminDiscounts() {
   return req('GET', '/api/admin/discounts')
@@ -172,6 +192,14 @@ export async function fetchAdminDiscounts() {
 
 export async function createDiscount(payload) {
   return req('POST', '/api/admin/discounts', payload)
+}
+
+export async function toggleDiscount(id) {
+  return req('PATCH', `/api/admin/discounts/${id}/toggle`)
+}
+
+export async function deleteDiscount(id) {
+  return req('DELETE', `/api/admin/discounts/${id}`)
 }
 
 // ── Legacy dummy stubs (하위호환) ──────────────────────

--- a/frontend/src/admin/api/adminApi.js
+++ b/frontend/src/admin/api/adminApi.js
@@ -1,0 +1,206 @@
+const API_BASE = import.meta.env.VITE_API_URL ?? ''
+
+function getToken() {
+  return localStorage.getItem('admin_token') ?? ''
+}
+
+function authHeaders() {
+  return {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${getToken()}`,
+  }
+}
+
+async function req(method, path, body) {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method,
+    headers: authHeaders(),
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ detail: '서버 오류가 발생했습니다' }))
+    throw new Error(err.detail ?? '오류가 발생했습니다')
+  }
+  return res.json()
+}
+
+// ── Auth ──────────────────────────────────────────────
+export async function login(username, password) {
+  const res = await fetch(`${API_BASE}/api/admin/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password }),
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}))
+    throw new Error(err.detail ?? '로그인에 실패했습니다')
+  }
+  return res.json()  // { access_token, expires_in }
+}
+
+export async function getMe() {
+  return req('GET', '/api/admin/auth/me')
+}
+
+export async function logout() {
+  await fetch(`${API_BASE}/api/admin/auth/logout`, { method: 'POST', headers: authHeaders() }).catch(() => {})
+  localStorage.removeItem('admin_token')
+}
+
+// ── Menu (Real API) ───────────────────────────────────
+export async function fetchAdminMenu() {
+  const res = await fetch(`${API_BASE}/api/menu?locale=ko`)
+  if (!res.ok) throw new Error('메뉴 로드 실패')
+  return res.json()
+}
+
+export async function createCategory(payload) {
+  return req('POST', '/api/admin/categories', payload)
+}
+
+export async function updateCategory(id, payload) {
+  return req('PATCH', `/api/admin/categories/${id}`, payload)
+}
+
+export async function deleteCategory(id) {
+  return req('DELETE', `/api/admin/categories/${id}`)
+}
+
+export async function createMenuItem(payload) {
+  return req('POST', '/api/admin/menu/items', payload)
+}
+
+export async function updateMenuItem(id, payload) {
+  return req('PATCH', `/api/admin/menu/items/${id}`, payload)
+}
+
+export async function deleteMenuItem(id) {
+  return req('DELETE', `/api/admin/menu/items/${id}`)
+}
+
+export async function uploadMenuImage(file) {
+  const fd = new FormData()
+  fd.append('file', file)
+  const res = await fetch(`${API_BASE}/api/admin/upload/image`, {
+    method: 'POST',
+    headers: { 'Authorization': `Bearer ${getToken()}` },
+    body: fd,
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ detail: '업로드 실패' }))
+    throw new Error(err.detail ?? '업로드 실패')
+  }
+  return res.json()  // { url }
+}
+
+export async function createMenuOption(itemId, payload) {
+  return req('POST', `/api/admin/menu/items/${itemId}/options`, payload)
+}
+
+export async function updateMenuOption(itemId, optionId, payload) {
+  return req('PATCH', `/api/admin/menu/items/${itemId}/options/${optionId}`, payload)
+}
+
+export async function deleteMenuOption(itemId, optionId) {
+  return req('DELETE', `/api/admin/menu/items/${itemId}/options/${optionId}`)
+}
+
+// ── Users (Real API) ─────────────────────────────────
+export async function listUsers(phone) {
+  const q = phone ? `?phone=${encodeURIComponent(phone)}` : ''
+  return req('GET', `/api/admin/users${q}`)
+}
+
+export async function getUserDetail(id) {
+  return req('GET', `/api/admin/users/${id}`)
+}
+
+export async function adjustPoints(id, delta, reason) {
+  return req('PATCH', `/api/admin/users/${id}/points`, { delta, reason })
+}
+
+// ── Orders (Dummy) ───────────────────────────────────
+const now = new Date()
+function t(h, m) {
+  const d = new Date(now)
+  d.setHours(h, m, 0, 0)
+  return d.toISOString()
+}
+
+export const DUMMY_ORDERS = [
+  { order_id:'ord-001', order_number:'1042', order_type:'EAT_IN',  status:'RECEIVED',  table_number:3,    subtotal:12000, discount_amount:0,    final_amount:12000, points_used:0,    points_earned:600,  created_at:t(14,31), payment_status:'SUCCESS',
+    items:[{name_ko:'F버거 세트',     quantity:1, unit_price:10000, total_price:10000, selected_options:['세트 변경 +2,000원','양념 감자튀김 +500원','콜라 +0원'], special_note:'양파 제외'},
+           {name_ko:'게살버거',       quantity:1, unit_price:5000,  total_price:5000,  selected_options:[], special_note:'제외 없음'}]},
+  { order_id:'ord-002', order_number:'1041', order_type:'TAKE_OUT', status:'COOKING',   table_number:null, subtotal:14200, discount_amount:0,    final_amount:14200, points_used:0,    points_earned:710,  created_at:t(14,28), payment_status:'SUCCESS',
+    items:[{name_ko:'불고기버거 세트', quantity:1, unit_price:9500,  total_price:9500,  selected_options:[], special_note:null},
+           {name_ko:'치즈버거',       quantity:1, unit_price:4700,  total_price:4700,  selected_options:[], special_note:null}]},
+  { order_id:'ord-003', order_number:'1040', order_type:'EAT_IN',  status:'COOKING',   table_number:7,    subtotal:6800,  discount_amount:0,    final_amount:6800,  points_used:0,    points_earned:340,  created_at:t(14,22), payment_status:'SUCCESS',
+    items:[{name_ko:'비건버거',       quantity:1, unit_price:6800,  total_price:6800,  selected_options:[], special_note:null}]},
+  { order_id:'ord-004', order_number:'1039', order_type:'EAT_IN',  status:'COOKING',   table_number:2,    subtotal:11000, discount_amount:0,    final_amount:11000, points_used:0,    points_earned:550,  created_at:t(14,17), payment_status:'SUCCESS',
+    items:[{name_ko:'더블불고기버거', quantity:1, unit_price:11000, total_price:11000, selected_options:[], special_note:null}]},
+  { order_id:'ord-005', order_number:'1038', order_type:'EAT_IN',  status:'CANCELLED', table_number:5,    subtotal:11000, discount_amount:0,    final_amount:11000, points_used:0,    points_earned:0,    created_at:t(14,16), payment_status:'REFUNDED',
+    items:[{name_ko:'치킨가슴살버거 세트', quantity:1, unit_price:11000, total_price:11000, selected_options:[], special_note:null}]},
+  { order_id:'ord-006', order_number:'1037', order_type:'TAKE_OUT', status:'READY',    table_number:null, subtotal:7500,  discount_amount:0,    final_amount:7500,  points_used:0,    points_earned:375,  created_at:t(14,11), payment_status:'SUCCESS',
+    items:[{name_ko:'새우버거 세트',  quantity:1, unit_price:7500,  total_price:7500,  selected_options:[], special_note:null}]},
+  { order_id:'ord-007', order_number:'1036', order_type:'TAKE_OUT', status:'COMPLETED', table_number:null, subtotal:10500, discount_amount:0,    final_amount:10500, points_used:0,    points_earned:525,  created_at:t(14,8),  payment_status:'SUCCESS',
+    items:[{name_ko:'모짜렐라버거 세트', quantity:1, unit_price:10500, total_price:10500, selected_options:[], special_note:null}]},
+  { order_id:'ord-008', order_number:'1035', order_type:'EAT_IN',  status:'COMPLETED', table_number:1,    subtotal:5500,  discount_amount:0,    final_amount:5500,  points_used:0,    points_earned:275,  created_at:t(14,2),  payment_status:'SUCCESS',
+    items:[{name_ko:'불고기버거',     quantity:1, unit_price:5500,  total_price:5500,  selected_options:[], special_note:null}]},
+  { order_id:'ord-009', order_number:'1034', order_type:'TAKE_OUT', status:'CANCELLED', table_number:null, subtotal:17500, discount_amount:0,    final_amount:17500, points_used:0,    points_earned:0,    created_at:t(13,56), payment_status:'FAILED',
+    items:[{name_ko:'데리버거 세트',  quantity:2, unit_price:8750,  total_price:17500, selected_options:[], special_note:null}]},
+  { order_id:'ord-010', order_number:'1033', order_type:'EAT_IN',  status:'COMPLETED', table_number:4,    subtotal:9800,  discount_amount:1000, final_amount:8800,  points_used:1000, points_earned:440,  created_at:t(13,49), payment_status:'SUCCESS',
+    items:[{name_ko:'그릴드비프버거', quantity:1, unit_price:9800,  total_price:9800,  selected_options:[], special_note:null}]},
+]
+
+// ── Payments (Dummy) ──────────────────────────────────
+export const DUMMY_PAYMENTS = [
+  { payment_id:'P2052', order_number:'1043', method:'네이버페이', amount:5600,  status:'PENDING',  failure_reason:null,          paid_at:'14:32', refunded_at:null },
+  { payment_id:'P2051', order_number:'1042', method:'카드',      amount:12000, status:'SUCCESS',  failure_reason:null,          paid_at:'14:31', refunded_at:null },
+  { payment_id:'P2050', order_number:'1041', method:'카드',      amount:14200, status:'SUCCESS',  failure_reason:null,          paid_at:'14:28', refunded_at:null },
+  { payment_id:'P2049', order_number:'1040', method:'카드',      amount:6800,  status:'SUCCESS',  failure_reason:null,          paid_at:'14:22', refunded_at:null },
+  { payment_id:'P2048', order_number:'1039', method:'현금',      amount:11000, status:'SUCCESS',  failure_reason:null,          paid_at:'14:17', refunded_at:null },
+  { payment_id:'P2047', order_number:'1038', method:'카드',      amount:11000, status:'REFUNDED', failure_reason:'고객 변심',    paid_at:'14:16', refunded_at:'14:20' },
+  { payment_id:'P2046', order_number:'1037', method:'삼성페이',  amount:7500,  status:'SUCCESS',  failure_reason:null,          paid_at:'14:11', refunded_at:null },
+  { payment_id:'P2045', order_number:'1036', method:'카드',      amount:10500, status:'SUCCESS',  failure_reason:null,          paid_at:'14:08', refunded_at:null },
+  { payment_id:'P2044', order_number:'1035', method:'카드',      amount:5500,  status:'SUCCESS',  failure_reason:null,          paid_at:'14:02', refunded_at:null },
+  { payment_id:'P2043', order_number:'1034', method:'카드',      amount:17500, status:'FAILED',   failure_reason:'한도 초과',    paid_at:'13:56', refunded_at:null },
+]
+
+// ── Stats (Dummy) ─────────────────────────────────────
+export const DUMMY_STATS = {
+  summary: { today_sales: 1284500, order_count: 147, avg_order_value: 8738 },
+  sales_7d: [
+    { date:'7/25', sales:920000,  order_count:105 },
+    { date:'7/26', sales:1050000, order_count:120 },
+    { date:'7/27', sales:870000,  order_count:98  },
+    { date:'7/28', sales:1100000, order_count:128 },
+    { date:'7/29', sales:980000,  order_count:112 },
+    { date:'7/30', sales:1180000, order_count:135 },
+    { date:'7/31', sales:1284500, order_count:147 },
+  ],
+  sales_30d: Array.from({length:30}, (_,i) => ({
+    date: `7/${i+1}`,
+    sales: 700000 + Math.round(Math.sin(i*0.4)*200000 + i*18000),
+    order_count: 80 + Math.round(Math.sin(i*0.4)*25 + i*2),
+  })),
+  popular_items: [
+    { menu_item_id:'1', name_ko:'F버거 세트',       quantity_sold:312, revenue:3120000 },
+    { menu_item_id:'2', name_ko:'불고기버거 세트',   quantity_sold:289, revenue:2745500 },
+    { menu_item_id:'3', name_ko:'치즈버거',          quantity_sold:241, revenue:1132700 },
+    { menu_item_id:'4', name_ko:'새우버거 세트',     quantity_sold:198, revenue:1485000 },
+    { menu_item_id:'5', name_ko:'비건버거',          quantity_sold:156, revenue:1060800 },
+  ],
+}
+
+// ── Coupons (Dummy) ───────────────────────────────────
+export const DUMMY_COUPONS = [
+  { id:'cp1', code:'WELCOME3000', discount_type:'CASH',    discount_value:3000, min_order_amount:5000,  used_count:142, max_usage_count:1000, valid_until:'~08.01', is_active:true },
+  { id:'cp2', code:'SALE10',     discount_type:'PERCENT',  discount_value:15,   min_order_amount:10000, used_count:12,  max_usage_count:150,  valid_until:'~08.01', is_active:true },
+  { id:'cp3', code:'SUMMER500',  discount_type:'CASH',    discount_value:3000, min_order_amount:5000,  used_count:13,  max_usage_count:500,  valid_until:'~06.30', is_active:false },
+]
+
+export const DUMMY_DISCOUNTS = [
+  { id:'dc1', name_ko:'여름 버거 할인',  target_type:'CATEGORY', discount_type:'CASH',    discount_value:3000, applicable_tier:'ALL',  valid_until:'~08.01', is_active:true },
+  { id:'dc2', name_ko:'VIP 전메뉴 할인', target_type:'ALL',      discount_type:'PERCENT',  discount_value:15,   applicable_tier:'GOLD', valid_until:'~08.01', is_active:true },
+  { id:'dc3', name_ko:'F버거 할인',      target_type:'MENU',     discount_type:'CASH',    discount_value:3000, applicable_tier:'ALL',  valid_until:'~04.12', is_active:false },
+]

--- a/frontend/src/admin/api/adminApi.js
+++ b/frontend/src/admin/api/adminApi.js
@@ -81,6 +81,14 @@ export async function deleteMenuItem(id) {
   return req('DELETE', `/api/admin/menu/items/${id}`)
 }
 
+export async function fetchSetOptions() {
+  return req('GET', '/api/admin/set-options')
+}
+
+export async function updateSetOption(payload) {
+  return req('PATCH', '/api/admin/set-options', payload)
+}
+
 export async function uploadMenuImage(file) {
   const fd = new FormData()
   fd.append('file', file)

--- a/frontend/src/admin/api/adminApi.js
+++ b/frontend/src/admin/api/adminApi.js
@@ -49,7 +49,10 @@ export async function logout() {
 
 // ── Menu (Real API) ───────────────────────────────────
 export async function fetchAdminMenu() {
-  const res = await fetch(`${API_BASE}/api/menu?locale=ko`)
+  // 관리자 전용 엔드포인트: 숨김 카테고리도 포함
+  const res = await fetch(`${API_BASE}/api/admin/menu`, {
+    headers: { 'Authorization': `Bearer ${getToken()}` },
+  })
   if (!res.ok) throw new Error('메뉴 로드 실패')
   return res.json()
 }

--- a/frontend/src/admin/components/Layout.jsx
+++ b/frontend/src/admin/components/Layout.jsx
@@ -1,0 +1,60 @@
+const NAV_ITEMS = [
+  { key: 'dashboard', label: '대시보드' },
+  { key: 'orders',    label: '주문 관리' },
+  { key: 'payments',  label: '결제·환불' },
+  { key: 'menu',      label: '메뉴 관리' },
+  { key: 'coupons',   label: '쿠폰·할인' },
+  { key: 'users',     label: '회원 관리' },
+]
+
+const PAGE_TITLES = {
+  dashboard: '대시보드',
+  orders:    '주문 관리',
+  payments:  '결제·환불',
+  menu:      '메뉴 관리',
+  coupons:   '쿠폰·할인',
+  users:     '회원 관리',
+}
+
+export default function Layout({ admin, currentPage, onNavigate, onLogout, children }) {
+  return (
+    <div className="admin-layout">
+      {/* Sidebar */}
+      <aside className="sidebar">
+        <div className="sidebar-logo">
+          <span className="sidebar-logo-icon">🍔</span>
+          <span>BURGER</span>
+        </div>
+        <nav className="sidebar-nav">
+          {NAV_ITEMS.map(item => (
+            <div
+              key={item.key}
+              className={`sidebar-nav-item${currentPage === item.key ? ' active' : ''}`}
+              onClick={() => onNavigate(item.key)}
+            >
+              {item.label}
+            </div>
+          ))}
+        </nav>
+      </aside>
+
+      {/* Main */}
+      <div className="admin-main">
+        {/* Header */}
+        <header className="admin-header">
+          <h1 className="admin-header-title">{PAGE_TITLES[currentPage] ?? ''}</h1>
+          <div className="admin-header-right">
+            <span className="admin-header-user-label">사용자</span>
+            <span className="admin-role-badge">{admin?.role ?? 'STAFF'}</span>
+            <button className="btn-logout" onClick={onLogout}>로그아웃</button>
+          </div>
+        </header>
+
+        {/* Content */}
+        <main className="admin-content">
+          {children}
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/admin/components/Layout.jsx
+++ b/frontend/src/admin/components/Layout.jsx
@@ -22,8 +22,7 @@ export default function Layout({ admin, currentPage, onNavigate, onLogout, child
       {/* Sidebar */}
       <aside className="sidebar">
         <div className="sidebar-logo">
-          <span className="sidebar-logo-icon">🍔</span>
-          <span>BURGER</span>
+          <img src="/logo.png" alt="버거 로고" style={{ height: 44, objectFit: 'contain', display: 'block' }} />
         </div>
         <nav className="sidebar-nav">
           {NAV_ITEMS.map(item => (

--- a/frontend/src/admin/components/StatusBadge.jsx
+++ b/frontend/src/admin/components/StatusBadge.jsx
@@ -1,0 +1,20 @@
+export default function StatusBadge({ type, value }) {
+  const ORDER_MAP = {
+    RECEIVED:  { cls: 'badge-received',  label: '접수' },
+    COOKING:   { cls: 'badge-cooking',   label: '조리중' },
+    READY:     { cls: 'badge-ready',     label: '준비완료' },
+    COMPLETED: { cls: 'badge-completed', label: '완료' },
+    CANCELLED: { cls: 'badge-cancelled', label: '취소' },
+  }
+  const PAY_MAP = {
+    PENDING:  { cls: 'badge-pending',  label: '대기' },
+    SUCCESS:  { cls: 'badge-success',  label: '완료' },
+    FAILED:   { cls: 'badge-failed',   label: '실패' },
+    REFUNDED: { cls: 'badge-refunded', label: '환불됨' },
+  }
+
+  const map = type === 'payment' ? PAY_MAP : ORDER_MAP
+  const info = map[value] ?? { cls: 'badge-pending', label: value }
+
+  return <span className={`badge ${info.cls}`}>{info.label}</span>
+}

--- a/frontend/src/admin/pages/CouponsPage.jsx
+++ b/frontend/src/admin/pages/CouponsPage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import {
   fetchAdminCoupons, createCoupon, issueCoupon, toggleCoupon, deleteCoupon,
   fetchAdminDiscounts, createDiscount, toggleDiscount, deleteDiscount,
+  fetchAdminMenu,
 } from '../api/adminApi.js'
 
 function Toggle({ checked, onChange, disabled }) {
@@ -101,16 +102,26 @@ function CouponModal({ onClose, onSave }) {
   )
 }
 
-function DiscountModal({ onClose, onSave }) {
+function DiscountModal({ onClose, onSave, menuMeta }) {
   const [form, setForm] = useState({
-    name_ko: '', name_en: '', target_type: 'ALL',
+    name_ko: '', name_en: '',
+    target_type: 'ALL', menu_item_id: null, category_id: null,
     discount_type: 'CASH', discount_value: '', applicable_tier: 'ALL',
   })
   const [loading, setLoading] = useState(false)
   const set = (k, v) => setForm(f => ({ ...f, [k]: v }))
 
+  const categories = menuMeta?.categories ?? []
+  const allItems   = menuMeta ? Object.values(menuMeta.menu_items).flat() : []
+
+  const handleTargetTypeChange = (v) => {
+    setForm(f => ({ ...f, target_type: v, menu_item_id: null, category_id: null }))
+  }
+
   const handleSave = async () => {
     if (!form.name_ko || !form.discount_value) { alert('이름과 할인값을 입력해 주세요'); return }
+    if (form.target_type === 'CATEGORY' && !form.category_id) { alert('카테고리를 선택해 주세요'); return }
+    if (form.target_type === 'MENU' && !form.menu_item_id) { alert('메뉴를 선택해 주세요'); return }
     setLoading(true)
     try {
       await onSave({ ...form, discount_value: Number(form.discount_value) })
@@ -124,7 +135,7 @@ function DiscountModal({ onClose, onSave }) {
 
   return (
     <div className="modal-overlay">
-      <div className="modal-box">
+      <div className="modal-box" style={{ width: 480 }}>
         <div className="modal-title">할인 생성</div>
         <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:'12px' }}>
           <div className="form-group" style={{ marginBottom:0 }}>
@@ -136,39 +147,60 @@ function DiscountModal({ onClose, onSave }) {
             <input className="form-input" value={form.name_en} onChange={e => set('name_en', e.target.value)} />
           </div>
         </div>
-        <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:'12px', marginTop:'12px' }}>
-          <div className="form-group" style={{ marginBottom:0 }}>
+
+        {/* 적용 대상 */}
+        <div style={{ marginTop: 12 }}>
+          <div className="form-group" style={{ marginBottom: 0 }}>
             <label className="form-label">적용 대상</label>
-            <select className="form-input" value={form.target_type} onChange={e => set('target_type', e.target.value)}>
-              <option value="ALL">전체</option>
-              <option value="CATEGORY">카테고리</option>
-              <option value="MENU">메뉴</option>
+            <select className="form-input" value={form.target_type} onChange={e => handleTargetTypeChange(e.target.value)}>
+              <option value="ALL">전체 메뉴</option>
+              <option value="CATEGORY">특정 카테고리</option>
+              <option value="MENU">특정 메뉴</option>
             </select>
           </div>
-          <div className="form-group" style={{ marginBottom:0 }}>
-            <label className="form-label">적용 등급</label>
-            <select className="form-input" value={form.applicable_tier} onChange={e => set('applicable_tier', e.target.value)}>
-              <option value="ALL">전체 회원</option>
-              <option value="STUDENT">학생</option>
-              <option value="SENIOR">시니어</option>
-              <option value="GOLD">VIP</option>
-            </select>
-          </div>
+          {form.target_type === 'CATEGORY' && (
+            <div className="form-group" style={{ marginBottom: 0, marginTop: 8 }}>
+              <label className="form-label">카테고리 선택 *</label>
+              <select
+                className="form-input"
+                value={form.category_id ?? ''}
+                onChange={e => set('category_id', e.target.value || null)}
+              >
+                <option value="">-- 카테고리 선택 --</option>
+                {categories.map(c => <option key={c.id} value={c.id}>{c.name_ko}</option>)}
+              </select>
+            </div>
+          )}
+          {form.target_type === 'MENU' && (
+            <div className="form-group" style={{ marginBottom: 0, marginTop: 8 }}>
+              <label className="form-label">메뉴 선택 *</label>
+              <select
+                className="form-input"
+                value={form.menu_item_id ?? ''}
+                onChange={e => set('menu_item_id', e.target.value || null)}
+              >
+                <option value="">-- 메뉴 선택 --</option>
+                {allItems.map(item => <option key={item.id} value={item.id}>{item.name_ko}</option>)}
+              </select>
+            </div>
+          )}
         </div>
+
         <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:'12px', marginTop:'12px' }}>
           <div className="form-group" style={{ marginBottom:0 }}>
             <label className="form-label">할인 유형</label>
             <select className="form-input" value={form.discount_type} onChange={e => set('discount_type', e.target.value)}>
-              <option value="CASH">정액</option>
-              <option value="PERCENT">정률</option>
+              <option value="CASH">정액 (원)</option>
+              <option value="PERCENT">정률 (%)</option>
             </select>
           </div>
           <div className="form-group" style={{ marginBottom:0 }}>
-            <label className="form-label">할인값 ({form.discount_type === 'CASH' ? '원' : '%'})</label>
+            <label className="form-label">할인값 ({form.discount_type === 'CASH' ? '원' : '%'}) *</label>
             <input className="form-input" type="number" value={form.discount_value}
               onChange={e => set('discount_value', e.target.value)} />
           </div>
         </div>
+
         <div className="modal-footer">
           <button className="btn-outline" onClick={onClose}>취소</button>
           <button className="btn-primary" onClick={handleSave} disabled={loading}>
@@ -240,6 +272,7 @@ export default function CouponsPage() {
   const [discountFilter,  setDiscountFilter]  = useState('all')
   const [coupons,         setCoupons]         = useState([])
   const [discounts,       setDiscounts]       = useState([])
+  const [menuMeta,        setMenuMeta]        = useState(null)
   const [loading,         setLoading]         = useState(true)
   const [error,           setError]           = useState('')
   const [showCouponModal,   setShowCouponModal]   = useState(false)
@@ -248,8 +281,8 @@ export default function CouponsPage() {
 
   const load = () => {
     setLoading(true)
-    Promise.all([fetchAdminCoupons(), fetchAdminDiscounts()])
-      .then(([c, d]) => { setCoupons(c); setDiscounts(d); setError('') })
+    Promise.all([fetchAdminCoupons(), fetchAdminDiscounts(), fetchAdminMenu()])
+      .then(([c, d, m]) => { setCoupons(c); setDiscounts(d); setMenuMeta(m); setError('') })
       .catch(e => setError(e.message))
       .finally(() => setLoading(false))
   }
@@ -418,13 +451,25 @@ export default function CouponsPage() {
               </thead>
               <tbody>
                 {filteredDiscounts.length === 0 && <tr><td colSpan={8} className="loading-text">할인이 없습니다</td></tr>}
-                {filteredDiscounts.map(d => (
+                {filteredDiscounts.map(d => {
+                  const allItems = menuMeta ? Object.values(menuMeta.menu_items).flat() : []
+                  const targetName = d.target_type === 'CATEGORY'
+                    ? (menuMeta?.categories?.find(c => c.id === d.category_id)?.name_ko ?? d.category_id)
+                    : d.target_type === 'MENU'
+                      ? (allItems.find(i => i.id === d.menu_item_id)?.name_ko ?? d.menu_item_id)
+                      : null
+                  return (
                   <tr key={d.id} style={{ color: d.is_active ? '#222' : '#bbb' }}>
                     <td style={{ fontWeight:'500' }}>{d.name_ko}</td>
                     <td>
                       <span style={{ border:'1px solid #ddd', borderRadius:'999px', padding:'2px 8px', fontSize:'12px' }}>
                         {TARGET_LABELS[d.target_type] ?? d.target_type}
                       </span>
+                      {targetName && (
+                        <span style={{ marginLeft: 4, fontSize: 12, color: '#744032', fontWeight: 600 }}>
+                          {targetName}
+                        </span>
+                      )}
                     </td>
                     <td>{d.discount_type === 'CASH' ? '정액' : '정률'}</td>
                     <td style={{ fontWeight:'600' }}>
@@ -445,7 +490,8 @@ export default function CouponsPage() {
                       >삭제</button>
                     </td>
                   </tr>
-                ))}
+                  )
+                })}
               </tbody>
             </table>
           </div>
@@ -453,7 +499,7 @@ export default function CouponsPage() {
       )}
 
       {showCouponModal   && <CouponModal   onClose={() => setShowCouponModal(false)}   onSave={handleCreateCoupon} />}
-      {showDiscountModal && <DiscountModal  onClose={() => setShowDiscountModal(false)} onSave={handleCreateDiscount} />}
+      {showDiscountModal && <DiscountModal  onClose={() => setShowDiscountModal(false)} onSave={handleCreateDiscount} menuMeta={menuMeta} />}
       {showIssueModal    && <IssueModal     coupons={coupons.filter(c => c.is_active)}  onClose={() => setShowIssueModal(false)} />}
     </div>
   )

--- a/frontend/src/admin/pages/CouponsPage.jsx
+++ b/frontend/src/admin/pages/CouponsPage.jsx
@@ -1,20 +1,42 @@
-import { useState } from 'react'
-import { DUMMY_COUPONS, DUMMY_DISCOUNTS } from '../api/adminApi.js'
+import { useState, useEffect } from 'react'
+import {
+  fetchAdminCoupons, createCoupon, issueCoupon,
+  fetchAdminDiscounts, createDiscount,
+} from '../api/adminApi.js'
 
 const TARGET_LABELS = { MENU: '메뉴', CATEGORY: '카테고리', ALL: '전체' }
-const TIER_LABELS = { ALL: '전체 회원', STUDENT: '학생', SENIOR: '시니어', GOLD: 'VIP' }
+const TIER_LABELS   = { ALL: '전체 회원', STUDENT: '학생', SENIOR: '시니어', GOLD: 'VIP' }
+
+function fmtDate(d) {
+  if (!d) return '–'
+  return String(d).slice(0, 10)
+}
 
 function CouponModal({ onClose, onSave }) {
-  const [form, setForm] = useState({ code:'', discount_type:'CASH', discount_value:'', min_order_amount:'', max_usage_count:'' })
+  const [form, setForm] = useState({
+    code: '', discount_type: 'CASH', discount_value: '',
+    min_order_amount: '', max_usage_count: '',
+  })
   const [loading, setLoading] = useState(false)
   const set = (k, v) => setForm(f => ({ ...f, [k]: v }))
 
   const handleSave = async () => {
     if (!form.code || !form.discount_value) { alert('코드와 할인값을 입력해 주세요'); return }
     setLoading(true)
-    await onSave(form)
-    setLoading(false)
-    onClose()
+    try {
+      await onSave({
+        code: form.code,
+        discount_type: form.discount_type,
+        discount_value: Number(form.discount_value),
+        min_order_amount: Number(form.min_order_amount) || 0,
+        max_usage_count:  Number(form.max_usage_count)  || 0,
+      })
+      onClose()
+    } catch (e) {
+      alert(e.message)
+    } finally {
+      setLoading(false)
+    }
   }
 
   return (
@@ -23,7 +45,9 @@ function CouponModal({ onClose, onSave }) {
         <div className="modal-title">쿠폰 생성</div>
         <div className="form-group">
           <label className="form-label">쿠폰 코드</label>
-          <input className="form-input" value={form.code} onChange={e => set('code', e.target.value.toUpperCase())} placeholder="예: SUMMER2026" />
+          <input className="form-input" value={form.code}
+            onChange={e => set('code', e.target.value.toUpperCase())}
+            placeholder="예: SUMMER2026" />
         </div>
         <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:'12px' }}>
           <div className="form-group" style={{ marginBottom:0 }}>
@@ -35,22 +59,27 @@ function CouponModal({ onClose, onSave }) {
           </div>
           <div className="form-group" style={{ marginBottom:0 }}>
             <label className="form-label">할인값 ({form.discount_type === 'CASH' ? '원' : '%'})</label>
-            <input className="form-input" type="number" value={form.discount_value} onChange={e => set('discount_value', e.target.value)} />
+            <input className="form-input" type="number" value={form.discount_value}
+              onChange={e => set('discount_value', e.target.value)} />
           </div>
         </div>
         <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:'12px', marginTop:'12px' }}>
           <div className="form-group" style={{ marginBottom:0 }}>
             <label className="form-label">최소 주문금액 (원)</label>
-            <input className="form-input" type="number" value={form.min_order_amount} onChange={e => set('min_order_amount', e.target.value)} placeholder="0 = 제한없음" />
+            <input className="form-input" type="number" value={form.min_order_amount}
+              onChange={e => set('min_order_amount', e.target.value)} placeholder="0 = 제한없음" />
           </div>
           <div className="form-group" style={{ marginBottom:0 }}>
             <label className="form-label">최대 사용 횟수</label>
-            <input className="form-input" type="number" value={form.max_usage_count} onChange={e => set('max_usage_count', e.target.value)} placeholder="0 = 무제한" />
+            <input className="form-input" type="number" value={form.max_usage_count}
+              onChange={e => set('max_usage_count', e.target.value)} placeholder="0 = 무제한" />
           </div>
         </div>
         <div className="modal-footer">
           <button className="btn-outline" onClick={onClose}>취소</button>
-          <button className="btn-primary" onClick={handleSave} disabled={loading}>{loading ? '생성 중…' : '생성'}</button>
+          <button className="btn-primary" onClick={handleSave} disabled={loading}>
+            {loading ? '생성 중…' : '생성'}
+          </button>
         </div>
       </div>
     </div>
@@ -58,27 +87,41 @@ function CouponModal({ onClose, onSave }) {
 }
 
 function DiscountModal({ onClose, onSave }) {
-  const [form, setForm] = useState({ name_ko:'', target_type:'ALL', discount_type:'CASH', discount_value:'', applicable_tier:'ALL' })
+  const [form, setForm] = useState({
+    name_ko: '', name_en: '', target_type: 'ALL',
+    discount_type: 'CASH', discount_value: '', applicable_tier: 'ALL',
+  })
   const [loading, setLoading] = useState(false)
   const set = (k, v) => setForm(f => ({ ...f, [k]: v }))
 
   const handleSave = async () => {
     if (!form.name_ko || !form.discount_value) { alert('이름과 할인값을 입력해 주세요'); return }
     setLoading(true)
-    await onSave(form)
-    setLoading(false)
-    onClose()
+    try {
+      await onSave({ ...form, discount_value: Number(form.discount_value) })
+      onClose()
+    } catch (e) {
+      alert(e.message)
+    } finally {
+      setLoading(false)
+    }
   }
 
   return (
     <div className="modal-overlay">
       <div className="modal-box">
         <div className="modal-title">할인 생성</div>
-        <div className="form-group">
-          <label className="form-label">할인 이름</label>
-          <input className="form-input" value={form.name_ko} onChange={e => set('name_ko', e.target.value)} placeholder="예: 여름 특별 할인" />
-        </div>
         <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:'12px' }}>
+          <div className="form-group" style={{ marginBottom:0 }}>
+            <label className="form-label">이름 (한국어) *</label>
+            <input className="form-input" value={form.name_ko} onChange={e => set('name_ko', e.target.value)} />
+          </div>
+          <div className="form-group" style={{ marginBottom:0 }}>
+            <label className="form-label">이름 (영어)</label>
+            <input className="form-input" value={form.name_en} onChange={e => set('name_en', e.target.value)} />
+          </div>
+        </div>
+        <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:'12px', marginTop:'12px' }}>
           <div className="form-group" style={{ marginBottom:0 }}>
             <label className="form-label">적용 대상</label>
             <select className="form-input" value={form.target_type} onChange={e => set('target_type', e.target.value)}>
@@ -107,46 +150,69 @@ function DiscountModal({ onClose, onSave }) {
           </div>
           <div className="form-group" style={{ marginBottom:0 }}>
             <label className="form-label">할인값 ({form.discount_type === 'CASH' ? '원' : '%'})</label>
-            <input className="form-input" type="number" value={form.discount_value} onChange={e => set('discount_value', e.target.value)} />
+            <input className="form-input" type="number" value={form.discount_value}
+              onChange={e => set('discount_value', e.target.value)} />
           </div>
         </div>
         <div className="modal-footer">
           <button className="btn-outline" onClick={onClose}>취소</button>
-          <button className="btn-primary" onClick={handleSave} disabled={loading}>{loading ? '생성 중…' : '생성'}</button>
+          <button className="btn-primary" onClick={handleSave} disabled={loading}>
+            {loading ? '생성 중…' : '생성'}
+          </button>
         </div>
       </div>
     </div>
   )
 }
 
-function IssueModal({ onClose, onIssue }) {
-  const [phone, setPhone] = useState('')
-  const [couponCode, setCouponCode] = useState('')
-  const [loading, setLoading] = useState(false)
+function IssueModal({ coupons, onClose }) {
+  const [selectedId, setSelectedId] = useState(coupons[0]?.id ?? '')
+  const [phone, setPhone]           = useState('')
+  const [loading, setLoading]       = useState(false)
+  const [result, setResult]         = useState('')
 
   const handleIssue = async () => {
-    if (!phone || !couponCode) { alert('전화번호와 쿠폰 코드를 입력해 주세요'); return }
+    if (!phone.trim()) { alert('전화번호를 입력해 주세요'); return }
+    if (!selectedId)   { alert('쿠폰을 선택해 주세요'); return }
     setLoading(true)
-    await onIssue(phone, couponCode)
-    setLoading(false)
-    onClose()
+    try {
+      await issueCoupon(selectedId, phone.trim())
+      setResult('발급 완료!')
+    } catch (e) {
+      alert(`발급 실패: ${e.message}`)
+    } finally {
+      setLoading(false)
+    }
   }
 
   return (
     <div className="modal-overlay">
       <div className="modal-box">
         <div className="modal-title">회원에게 쿠폰 발급</div>
-        <div className="form-group">
-          <label className="form-label">전화번호</label>
-          <input className="form-input" value={phone} onChange={e => setPhone(e.target.value)} placeholder="010-0000-0000" />
-        </div>
-        <div className="form-group">
-          <label className="form-label">쿠폰 코드</label>
-          <input className="form-input" value={couponCode} onChange={e => setCouponCode(e.target.value.toUpperCase())} placeholder="예: WELCOME3000" />
-        </div>
+        {result
+          ? <div style={{ textAlign:'center', padding:'20px 0', fontSize:'15px', color:'#744032', fontWeight:'700' }}>{result}</div>
+          : (
+            <>
+              <div className="form-group">
+                <label className="form-label">쿠폰 선택</label>
+                <select className="form-input" value={selectedId} onChange={e => setSelectedId(e.target.value)}>
+                  {coupons.map(c => <option key={c.id} value={c.id}>{c.code}</option>)}
+                </select>
+              </div>
+              <div className="form-group">
+                <label className="form-label">전화번호</label>
+                <input className="form-input" value={phone} onChange={e => setPhone(e.target.value)} placeholder="010-0000-0000" />
+              </div>
+            </>
+          )
+        }
         <div className="modal-footer">
-          <button className="btn-outline" onClick={onClose}>취소</button>
-          <button className="btn-primary" onClick={handleIssue} disabled={loading}>{loading ? '발급 중…' : '발급'}</button>
+          <button className="btn-outline" onClick={onClose}>{result ? '닫기' : '취소'}</button>
+          {!result && (
+            <button className="btn-primary" onClick={handleIssue} disabled={loading}>
+              {loading ? '발급 중…' : '발급'}
+            </button>
+          )}
         </div>
       </div>
     </div>
@@ -154,71 +220,60 @@ function IssueModal({ onClose, onIssue }) {
 }
 
 export default function CouponsPage() {
-  const [tab, setTab] = useState('coupon')
-  const [couponFilter, setCouponFilter] = useState('all')
-  const [discountFilter, setDiscountFilter] = useState('all')
-  const [coupons, setCoupons] = useState(DUMMY_COUPONS)
-  const [discounts, setDiscounts] = useState(DUMMY_DISCOUNTS)
-  const [showCouponModal, setShowCouponModal] = useState(false)
+  const [tab,             setTab]             = useState('coupon')
+  const [couponFilter,    setCouponFilter]    = useState('all')
+  const [discountFilter,  setDiscountFilter]  = useState('all')
+  const [coupons,         setCoupons]         = useState([])
+  const [discounts,       setDiscounts]       = useState([])
+  const [loading,         setLoading]         = useState(true)
+  const [error,           setError]           = useState('')
+  const [showCouponModal,   setShowCouponModal]   = useState(false)
   const [showDiscountModal, setShowDiscountModal] = useState(false)
-  const [showIssueModal, setShowIssueModal] = useState(false)
+  const [showIssueModal,    setShowIssueModal]    = useState(false)
 
-  const handleCreateCoupon = (form) => {
-    const nc = {
-      id: `cp${Date.now()}`,
-      code: form.code,
-      discount_type: form.discount_type,
-      discount_value: Number(form.discount_value),
-      min_order_amount: Number(form.min_order_amount) || 0,
-      used_count: 0,
-      max_usage_count: Number(form.max_usage_count) || 0,
-      valid_until: '–',
-      is_active: true,
-    }
-    setCoupons(prev => [nc, ...prev])
+  const load = () => {
+    setLoading(true)
+    Promise.all([fetchAdminCoupons(), fetchAdminDiscounts()])
+      .then(([c, d]) => { setCoupons(c); setDiscounts(d); setError('') })
+      .catch(e => setError(e.message))
+      .finally(() => setLoading(false))
   }
 
-  const handleCreateDiscount = (form) => {
-    const nd = {
-      id: `dc${Date.now()}`,
-      name_ko: form.name_ko,
-      target_type: form.target_type,
-      discount_type: form.discount_type,
-      discount_value: Number(form.discount_value),
-      applicable_tier: form.applicable_tier,
-      valid_until: '–',
-      is_active: true,
-    }
-    setDiscounts(prev => [nd, ...prev])
+  useEffect(() => { load() }, [])
+
+  const handleCreateCoupon = async (payload) => {
+    const c = await createCoupon(payload)
+    setCoupons(prev => [c, ...prev])
   }
 
-  const toggleCouponActive = (id) => {
-    setCoupons(prev => prev.map(c => c.id === id ? { ...c, is_active: !c.is_active } : c))
+  const handleCreateDiscount = async (payload) => {
+    const d = await createDiscount(payload)
+    setDiscounts(prev => [d, ...prev])
   }
 
-  const toggleDiscountActive = (id) => {
-    setDiscounts(prev => prev.map(d => d.id === id ? { ...d, is_active: !d.is_active } : d))
-  }
-
-  const filteredCoupons = coupons.filter(c =>
+  const filteredCoupons   = coupons.filter(c =>
     couponFilter === 'all' || (couponFilter === 'active' ? c.is_active : !c.is_active)
   )
   const filteredDiscounts = discounts.filter(d =>
     discountFilter === 'all' || (discountFilter === 'active' ? d.is_active : !d.is_active)
   )
 
+  if (loading) return <div className="loading-text">쿠폰/할인 로딩 중…</div>
+  if (error)   return <div className="loading-text" style={{ color:'#c00' }}>{error}</div>
+
   return (
     <div>
       {/* Tab */}
-      <div style={{ display:'flex', gap:'0', marginBottom:'20px', borderBottom:'2px solid #eee' }}>
+      <div style={{ display:'flex', marginBottom:'20px', borderBottom:'2px solid #eee' }}>
         {[['coupon','쿠폰'], ['discount','할인']].map(([k, label]) => (
           <button
             key={k}
             onClick={() => setTab(k)}
             style={{
               padding:'10px 24px', border:'none', background:'none', cursor:'pointer',
-              fontFamily:'Pretendard,sans-serif', fontSize:'15px', fontWeight: tab===k ? '700' : '400',
-              color: tab===k ? '#744032' : '#888',
+              fontFamily:'Pretendard,sans-serif', fontSize:'15px',
+              fontWeight: tab===k ? '700' : '400',
+              color:       tab===k ? '#744032' : '#888',
               borderBottom: tab===k ? '2px solid #744032' : '2px solid transparent',
               marginBottom:'-2px',
             }}
@@ -228,7 +283,7 @@ export default function CouponsPage() {
         ))}
       </div>
 
-      {/* Coupon tab */}
+      {/* ── 쿠폰 탭 ── */}
       {tab === 'coupon' && (
         <div>
           <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginBottom:'16px' }}>
@@ -239,7 +294,7 @@ export default function CouponsPage() {
             </div>
             <div style={{ display:'flex', gap:'8px' }}>
               <button className="btn-outline" onClick={() => setShowIssueModal(true)}>회원에게 발급</button>
-              <button className="btn-primary" onClick={() => setShowCouponModal(true)}>+ 쿠폰 생성</button>
+              <button className="btn-primary"  onClick={() => setShowCouponModal(true)}>+ 쿠폰 생성</button>
             </div>
           </div>
           <div className="card" style={{ padding:0, overflow:'hidden' }}>
@@ -253,32 +308,26 @@ export default function CouponsPage() {
                   <th>사용/최대</th>
                   <th>유효기한</th>
                   <th>활성</th>
-                  <th style={{width:50}}></th>
                 </tr>
               </thead>
               <tbody>
-                {filteredCoupons.length === 0 && <tr><td colSpan={8} className="loading-text">쿠폰이 없습니다</td></tr>}
+                {filteredCoupons.length === 0 && <tr><td colSpan={7} className="loading-text">쿠폰이 없습니다</td></tr>}
                 {filteredCoupons.map(c => (
                   <tr key={c.id} style={{ color: c.is_active ? '#222' : '#bbb' }}>
                     <td style={{ fontWeight:'600', fontFamily:'monospace', letterSpacing:'0.5px' }}>{c.code}</td>
                     <td>{c.discount_type === 'CASH' ? '정액' : '정률'}</td>
                     <td style={{ fontWeight:'600' }}>
                       {c.discount_type === 'CASH'
-                        ? `${c.discount_value.toLocaleString('ko-KR')}원`
+                        ? `${Number(c.discount_value).toLocaleString('ko-KR')}원`
                         : `${c.discount_value}%`}
                     </td>
-                    <td>{c.min_order_amount ? `${c.min_order_amount.toLocaleString('ko-KR')}원` : '–'}</td>
+                    <td>{c.min_order_amount ? `${Number(c.min_order_amount).toLocaleString('ko-KR')}원` : '–'}</td>
                     <td>{c.used_count}/{c.max_usage_count || '∞'}</td>
-                    <td style={{ fontSize:'13px', color:'#888' }}>{c.valid_until}</td>
+                    <td style={{ fontSize:'13px', color:'#888' }}>{fmtDate(c.valid_until)}</td>
                     <td>
                       <span className={`badge ${c.is_active ? 'badge-active' : 'badge-inactive'}`}>
                         {c.is_active ? '활성' : '비활성'}
                       </span>
-                    </td>
-                    <td>
-                      <button className="btn-outline btn-sm" onClick={() => toggleCouponActive(c.id)}>
-                        {c.is_active ? '비활성화' : '활성화'}
-                      </button>
                     </td>
                   </tr>
                 ))}
@@ -288,7 +337,7 @@ export default function CouponsPage() {
         </div>
       )}
 
-      {/* Discount tab */}
+      {/* ── 할인 탭 ── */}
       {tab === 'discount' && (
         <div>
           <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginBottom:'16px' }}>
@@ -310,11 +359,10 @@ export default function CouponsPage() {
                   <th>적용등급</th>
                   <th>유효기한</th>
                   <th>활성</th>
-                  <th style={{width:50}}></th>
                 </tr>
               </thead>
               <tbody>
-                {filteredDiscounts.length === 0 && <tr><td colSpan={8} className="loading-text">할인이 없습니다</td></tr>}
+                {filteredDiscounts.length === 0 && <tr><td colSpan={7} className="loading-text">할인이 없습니다</td></tr>}
                 {filteredDiscounts.map(d => (
                   <tr key={d.id} style={{ color: d.is_active ? '#222' : '#bbb' }}>
                     <td style={{ fontWeight:'500' }}>{d.name_ko}</td>
@@ -326,20 +374,15 @@ export default function CouponsPage() {
                     <td>{d.discount_type === 'CASH' ? '정액' : '정률'}</td>
                     <td style={{ fontWeight:'600' }}>
                       {d.discount_type === 'CASH'
-                        ? `${d.discount_value.toLocaleString('ko-KR')}원`
+                        ? `${Number(d.discount_value).toLocaleString('ko-KR')}원`
                         : `${d.discount_value}%`}
                     </td>
                     <td style={{ fontSize:'13px', color:'#888' }}>{TIER_LABELS[d.applicable_tier] ?? d.applicable_tier}</td>
-                    <td style={{ fontSize:'13px', color:'#888' }}>{d.valid_until}</td>
+                    <td style={{ fontSize:'13px', color:'#888' }}>{fmtDate(d.valid_until)}</td>
                     <td>
                       <span className={`badge ${d.is_active ? 'badge-active' : 'badge-inactive'}`}>
                         {d.is_active ? '활성' : '비활성'}
                       </span>
-                    </td>
-                    <td>
-                      <button className="btn-outline btn-sm" onClick={() => toggleDiscountActive(d.id)}>
-                        {d.is_active ? '비활성화' : '활성화'}
-                      </button>
                     </td>
                   </tr>
                 ))}
@@ -351,7 +394,7 @@ export default function CouponsPage() {
 
       {showCouponModal   && <CouponModal   onClose={() => setShowCouponModal(false)}   onSave={handleCreateCoupon} />}
       {showDiscountModal && <DiscountModal  onClose={() => setShowDiscountModal(false)} onSave={handleCreateDiscount} />}
-      {showIssueModal    && <IssueModal     onClose={() => setShowIssueModal(false)}    onIssue={async (p,c) => { alert(`${p}에게 ${c} 쿠폰을 발급했습니다 (더미)`) }} />}
+      {showIssueModal    && <IssueModal     coupons={coupons.filter(c => c.is_active)}  onClose={() => setShowIssueModal(false)} />}
     </div>
   )
 }

--- a/frontend/src/admin/pages/CouponsPage.jsx
+++ b/frontend/src/admin/pages/CouponsPage.jsx
@@ -1,0 +1,357 @@
+import { useState } from 'react'
+import { DUMMY_COUPONS, DUMMY_DISCOUNTS } from '../api/adminApi.js'
+
+const TARGET_LABELS = { MENU: '메뉴', CATEGORY: '카테고리', ALL: '전체' }
+const TIER_LABELS = { ALL: '전체 회원', STUDENT: '학생', SENIOR: '시니어', GOLD: 'VIP' }
+
+function CouponModal({ onClose, onSave }) {
+  const [form, setForm] = useState({ code:'', discount_type:'CASH', discount_value:'', min_order_amount:'', max_usage_count:'' })
+  const [loading, setLoading] = useState(false)
+  const set = (k, v) => setForm(f => ({ ...f, [k]: v }))
+
+  const handleSave = async () => {
+    if (!form.code || !form.discount_value) { alert('코드와 할인값을 입력해 주세요'); return }
+    setLoading(true)
+    await onSave(form)
+    setLoading(false)
+    onClose()
+  }
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-box">
+        <div className="modal-title">쿠폰 생성</div>
+        <div className="form-group">
+          <label className="form-label">쿠폰 코드</label>
+          <input className="form-input" value={form.code} onChange={e => set('code', e.target.value.toUpperCase())} placeholder="예: SUMMER2026" />
+        </div>
+        <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:'12px' }}>
+          <div className="form-group" style={{ marginBottom:0 }}>
+            <label className="form-label">할인 유형</label>
+            <select className="form-input" value={form.discount_type} onChange={e => set('discount_type', e.target.value)}>
+              <option value="CASH">정액</option>
+              <option value="PERCENT">정률</option>
+            </select>
+          </div>
+          <div className="form-group" style={{ marginBottom:0 }}>
+            <label className="form-label">할인값 ({form.discount_type === 'CASH' ? '원' : '%'})</label>
+            <input className="form-input" type="number" value={form.discount_value} onChange={e => set('discount_value', e.target.value)} />
+          </div>
+        </div>
+        <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:'12px', marginTop:'12px' }}>
+          <div className="form-group" style={{ marginBottom:0 }}>
+            <label className="form-label">최소 주문금액 (원)</label>
+            <input className="form-input" type="number" value={form.min_order_amount} onChange={e => set('min_order_amount', e.target.value)} placeholder="0 = 제한없음" />
+          </div>
+          <div className="form-group" style={{ marginBottom:0 }}>
+            <label className="form-label">최대 사용 횟수</label>
+            <input className="form-input" type="number" value={form.max_usage_count} onChange={e => set('max_usage_count', e.target.value)} placeholder="0 = 무제한" />
+          </div>
+        </div>
+        <div className="modal-footer">
+          <button className="btn-outline" onClick={onClose}>취소</button>
+          <button className="btn-primary" onClick={handleSave} disabled={loading}>{loading ? '생성 중…' : '생성'}</button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function DiscountModal({ onClose, onSave }) {
+  const [form, setForm] = useState({ name_ko:'', target_type:'ALL', discount_type:'CASH', discount_value:'', applicable_tier:'ALL' })
+  const [loading, setLoading] = useState(false)
+  const set = (k, v) => setForm(f => ({ ...f, [k]: v }))
+
+  const handleSave = async () => {
+    if (!form.name_ko || !form.discount_value) { alert('이름과 할인값을 입력해 주세요'); return }
+    setLoading(true)
+    await onSave(form)
+    setLoading(false)
+    onClose()
+  }
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-box">
+        <div className="modal-title">할인 생성</div>
+        <div className="form-group">
+          <label className="form-label">할인 이름</label>
+          <input className="form-input" value={form.name_ko} onChange={e => set('name_ko', e.target.value)} placeholder="예: 여름 특별 할인" />
+        </div>
+        <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:'12px' }}>
+          <div className="form-group" style={{ marginBottom:0 }}>
+            <label className="form-label">적용 대상</label>
+            <select className="form-input" value={form.target_type} onChange={e => set('target_type', e.target.value)}>
+              <option value="ALL">전체</option>
+              <option value="CATEGORY">카테고리</option>
+              <option value="MENU">메뉴</option>
+            </select>
+          </div>
+          <div className="form-group" style={{ marginBottom:0 }}>
+            <label className="form-label">적용 등급</label>
+            <select className="form-input" value={form.applicable_tier} onChange={e => set('applicable_tier', e.target.value)}>
+              <option value="ALL">전체 회원</option>
+              <option value="STUDENT">학생</option>
+              <option value="SENIOR">시니어</option>
+              <option value="GOLD">VIP</option>
+            </select>
+          </div>
+        </div>
+        <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:'12px', marginTop:'12px' }}>
+          <div className="form-group" style={{ marginBottom:0 }}>
+            <label className="form-label">할인 유형</label>
+            <select className="form-input" value={form.discount_type} onChange={e => set('discount_type', e.target.value)}>
+              <option value="CASH">정액</option>
+              <option value="PERCENT">정률</option>
+            </select>
+          </div>
+          <div className="form-group" style={{ marginBottom:0 }}>
+            <label className="form-label">할인값 ({form.discount_type === 'CASH' ? '원' : '%'})</label>
+            <input className="form-input" type="number" value={form.discount_value} onChange={e => set('discount_value', e.target.value)} />
+          </div>
+        </div>
+        <div className="modal-footer">
+          <button className="btn-outline" onClick={onClose}>취소</button>
+          <button className="btn-primary" onClick={handleSave} disabled={loading}>{loading ? '생성 중…' : '생성'}</button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function IssueModal({ onClose, onIssue }) {
+  const [phone, setPhone] = useState('')
+  const [couponCode, setCouponCode] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const handleIssue = async () => {
+    if (!phone || !couponCode) { alert('전화번호와 쿠폰 코드를 입력해 주세요'); return }
+    setLoading(true)
+    await onIssue(phone, couponCode)
+    setLoading(false)
+    onClose()
+  }
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-box">
+        <div className="modal-title">회원에게 쿠폰 발급</div>
+        <div className="form-group">
+          <label className="form-label">전화번호</label>
+          <input className="form-input" value={phone} onChange={e => setPhone(e.target.value)} placeholder="010-0000-0000" />
+        </div>
+        <div className="form-group">
+          <label className="form-label">쿠폰 코드</label>
+          <input className="form-input" value={couponCode} onChange={e => setCouponCode(e.target.value.toUpperCase())} placeholder="예: WELCOME3000" />
+        </div>
+        <div className="modal-footer">
+          <button className="btn-outline" onClick={onClose}>취소</button>
+          <button className="btn-primary" onClick={handleIssue} disabled={loading}>{loading ? '발급 중…' : '발급'}</button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function CouponsPage() {
+  const [tab, setTab] = useState('coupon')
+  const [couponFilter, setCouponFilter] = useState('all')
+  const [discountFilter, setDiscountFilter] = useState('all')
+  const [coupons, setCoupons] = useState(DUMMY_COUPONS)
+  const [discounts, setDiscounts] = useState(DUMMY_DISCOUNTS)
+  const [showCouponModal, setShowCouponModal] = useState(false)
+  const [showDiscountModal, setShowDiscountModal] = useState(false)
+  const [showIssueModal, setShowIssueModal] = useState(false)
+
+  const handleCreateCoupon = (form) => {
+    const nc = {
+      id: `cp${Date.now()}`,
+      code: form.code,
+      discount_type: form.discount_type,
+      discount_value: Number(form.discount_value),
+      min_order_amount: Number(form.min_order_amount) || 0,
+      used_count: 0,
+      max_usage_count: Number(form.max_usage_count) || 0,
+      valid_until: '–',
+      is_active: true,
+    }
+    setCoupons(prev => [nc, ...prev])
+  }
+
+  const handleCreateDiscount = (form) => {
+    const nd = {
+      id: `dc${Date.now()}`,
+      name_ko: form.name_ko,
+      target_type: form.target_type,
+      discount_type: form.discount_type,
+      discount_value: Number(form.discount_value),
+      applicable_tier: form.applicable_tier,
+      valid_until: '–',
+      is_active: true,
+    }
+    setDiscounts(prev => [nd, ...prev])
+  }
+
+  const toggleCouponActive = (id) => {
+    setCoupons(prev => prev.map(c => c.id === id ? { ...c, is_active: !c.is_active } : c))
+  }
+
+  const toggleDiscountActive = (id) => {
+    setDiscounts(prev => prev.map(d => d.id === id ? { ...d, is_active: !d.is_active } : d))
+  }
+
+  const filteredCoupons = coupons.filter(c =>
+    couponFilter === 'all' || (couponFilter === 'active' ? c.is_active : !c.is_active)
+  )
+  const filteredDiscounts = discounts.filter(d =>
+    discountFilter === 'all' || (discountFilter === 'active' ? d.is_active : !d.is_active)
+  )
+
+  return (
+    <div>
+      {/* Tab */}
+      <div style={{ display:'flex', gap:'0', marginBottom:'20px', borderBottom:'2px solid #eee' }}>
+        {[['coupon','쿠폰'], ['discount','할인']].map(([k, label]) => (
+          <button
+            key={k}
+            onClick={() => setTab(k)}
+            style={{
+              padding:'10px 24px', border:'none', background:'none', cursor:'pointer',
+              fontFamily:'Pretendard,sans-serif', fontSize:'15px', fontWeight: tab===k ? '700' : '400',
+              color: tab===k ? '#744032' : '#888',
+              borderBottom: tab===k ? '2px solid #744032' : '2px solid transparent',
+              marginBottom:'-2px',
+            }}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* Coupon tab */}
+      {tab === 'coupon' && (
+        <div>
+          <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginBottom:'16px' }}>
+            <div className="filter-chips">
+              {[['all','전체'],['active','활성'],['inactive','비활성']].map(([k,l]) => (
+                <button key={k} className={`chip${couponFilter===k?' active':''}`} onClick={() => setCouponFilter(k)}>{l}</button>
+              ))}
+            </div>
+            <div style={{ display:'flex', gap:'8px' }}>
+              <button className="btn-outline" onClick={() => setShowIssueModal(true)}>회원에게 발급</button>
+              <button className="btn-primary" onClick={() => setShowCouponModal(true)}>+ 쿠폰 생성</button>
+            </div>
+          </div>
+          <div className="card" style={{ padding:0, overflow:'hidden' }}>
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th>코드</th>
+                  <th>유형</th>
+                  <th>할인값</th>
+                  <th>최소주문</th>
+                  <th>사용/최대</th>
+                  <th>유효기한</th>
+                  <th>활성</th>
+                  <th style={{width:50}}></th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredCoupons.length === 0 && <tr><td colSpan={8} className="loading-text">쿠폰이 없습니다</td></tr>}
+                {filteredCoupons.map(c => (
+                  <tr key={c.id} style={{ color: c.is_active ? '#222' : '#bbb' }}>
+                    <td style={{ fontWeight:'600', fontFamily:'monospace', letterSpacing:'0.5px' }}>{c.code}</td>
+                    <td>{c.discount_type === 'CASH' ? '정액' : '정률'}</td>
+                    <td style={{ fontWeight:'600' }}>
+                      {c.discount_type === 'CASH'
+                        ? `${c.discount_value.toLocaleString('ko-KR')}원`
+                        : `${c.discount_value}%`}
+                    </td>
+                    <td>{c.min_order_amount ? `${c.min_order_amount.toLocaleString('ko-KR')}원` : '–'}</td>
+                    <td>{c.used_count}/{c.max_usage_count || '∞'}</td>
+                    <td style={{ fontSize:'13px', color:'#888' }}>{c.valid_until}</td>
+                    <td>
+                      <span className={`badge ${c.is_active ? 'badge-active' : 'badge-inactive'}`}>
+                        {c.is_active ? '활성' : '비활성'}
+                      </span>
+                    </td>
+                    <td>
+                      <button className="btn-outline btn-sm" onClick={() => toggleCouponActive(c.id)}>
+                        {c.is_active ? '비활성화' : '활성화'}
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Discount tab */}
+      {tab === 'discount' && (
+        <div>
+          <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginBottom:'16px' }}>
+            <div className="filter-chips">
+              {[['all','전체'],['active','활성'],['inactive','비활성']].map(([k,l]) => (
+                <button key={k} className={`chip${discountFilter===k?' active':''}`} onClick={() => setDiscountFilter(k)}>{l}</button>
+              ))}
+            </div>
+            <button className="btn-primary" onClick={() => setShowDiscountModal(true)}>+ 할인 생성</button>
+          </div>
+          <div className="card" style={{ padding:0, overflow:'hidden' }}>
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th>이름</th>
+                  <th>적용대상</th>
+                  <th>유형</th>
+                  <th>할인값</th>
+                  <th>적용등급</th>
+                  <th>유효기한</th>
+                  <th>활성</th>
+                  <th style={{width:50}}></th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredDiscounts.length === 0 && <tr><td colSpan={8} className="loading-text">할인이 없습니다</td></tr>}
+                {filteredDiscounts.map(d => (
+                  <tr key={d.id} style={{ color: d.is_active ? '#222' : '#bbb' }}>
+                    <td style={{ fontWeight:'500' }}>{d.name_ko}</td>
+                    <td>
+                      <span style={{ border:'1px solid #ddd', borderRadius:'999px', padding:'2px 8px', fontSize:'12px' }}>
+                        {TARGET_LABELS[d.target_type] ?? d.target_type}
+                      </span>
+                    </td>
+                    <td>{d.discount_type === 'CASH' ? '정액' : '정률'}</td>
+                    <td style={{ fontWeight:'600' }}>
+                      {d.discount_type === 'CASH'
+                        ? `${d.discount_value.toLocaleString('ko-KR')}원`
+                        : `${d.discount_value}%`}
+                    </td>
+                    <td style={{ fontSize:'13px', color:'#888' }}>{TIER_LABELS[d.applicable_tier] ?? d.applicable_tier}</td>
+                    <td style={{ fontSize:'13px', color:'#888' }}>{d.valid_until}</td>
+                    <td>
+                      <span className={`badge ${d.is_active ? 'badge-active' : 'badge-inactive'}`}>
+                        {d.is_active ? '활성' : '비활성'}
+                      </span>
+                    </td>
+                    <td>
+                      <button className="btn-outline btn-sm" onClick={() => toggleDiscountActive(d.id)}>
+                        {d.is_active ? '비활성화' : '활성화'}
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {showCouponModal   && <CouponModal   onClose={() => setShowCouponModal(false)}   onSave={handleCreateCoupon} />}
+      {showDiscountModal && <DiscountModal  onClose={() => setShowDiscountModal(false)} onSave={handleCreateDiscount} />}
+      {showIssueModal    && <IssueModal     onClose={() => setShowIssueModal(false)}    onIssue={async (p,c) => { alert(`${p}에게 ${c} 쿠폰을 발급했습니다 (더미)`) }} />}
+    </div>
+  )
+}

--- a/frontend/src/admin/pages/CouponsPage.jsx
+++ b/frontend/src/admin/pages/CouponsPage.jsx
@@ -6,11 +6,16 @@ import {
 
 function Toggle({ checked, onChange, disabled }) {
   return (
-    <label className="toggle" onClick={e => { e.stopPropagation(); if (!disabled) onChange(!checked) }}>
-      <input type="checkbox" checked={checked} onChange={() => {}} />
-      <div className="toggle-track" />
+    <div
+      role="switch"
+      aria-checked={checked}
+      className="toggle"
+      onClick={e => { e.stopPropagation(); if (!disabled) onChange(!checked) }}
+      style={{ cursor: disabled ? 'default' : 'pointer', opacity: disabled ? 0.5 : 1, display: 'inline-flex', alignItems: 'center' }}
+    >
+      <div className="toggle-track" style={{ background: checked ? '#744032' : '#ccc' }} />
       <div className="toggle-thumb" />
-    </label>
+    </div>
   )
 }
 

--- a/frontend/src/admin/pages/CouponsPage.jsx
+++ b/frontend/src/admin/pages/CouponsPage.jsx
@@ -9,11 +9,11 @@ function Toggle({ checked, onChange, disabled }) {
     <div
       role="switch"
       aria-checked={checked}
-      className="toggle"
+      className={`toggle${checked ? ' checked' : ''}`}
       onClick={e => { e.stopPropagation(); if (!disabled) onChange(!checked) }}
-      style={{ cursor: disabled ? 'default' : 'pointer', opacity: disabled ? 0.5 : 1, display: 'inline-flex', alignItems: 'center' }}
+      style={{ cursor: disabled ? 'default' : 'pointer', opacity: disabled ? 0.5 : 1 }}
     >
-      <div className="toggle-track" style={{ background: checked ? '#744032' : '#ccc' }} />
+      <div className="toggle-track" />
       <div className="toggle-thumb" />
     </div>
   )

--- a/frontend/src/admin/pages/CouponsPage.jsx
+++ b/frontend/src/admin/pages/CouponsPage.jsx
@@ -1,8 +1,18 @@
 import { useState, useEffect } from 'react'
 import {
-  fetchAdminCoupons, createCoupon, issueCoupon,
-  fetchAdminDiscounts, createDiscount,
+  fetchAdminCoupons, createCoupon, issueCoupon, toggleCoupon, deleteCoupon,
+  fetchAdminDiscounts, createDiscount, toggleDiscount, deleteDiscount,
 } from '../api/adminApi.js'
+
+function Toggle({ checked, onChange, disabled }) {
+  return (
+    <label className="toggle" onClick={e => { e.stopPropagation(); if (!disabled) onChange(!checked) }}>
+      <input type="checkbox" checked={checked} onChange={() => {}} />
+      <div className="toggle-track" />
+      <div className="toggle-thumb" />
+    </label>
+  )
+}
 
 const TARGET_LABELS = { MENU: '메뉴', CATEGORY: '카테고리', ALL: '전체' }
 const TIER_LABELS   = { ALL: '전체 회원', STUDENT: '학생', SENIOR: '시니어', GOLD: 'VIP' }
@@ -246,9 +256,42 @@ export default function CouponsPage() {
     setCoupons(prev => [c, ...prev])
   }
 
+  const handleToggleCoupon = async (id) => {
+    try {
+      const updated = await toggleCoupon(id)
+      setCoupons(prev => prev.map(c => c.id === id ? updated : c))
+    } catch (e) { alert(e.message) }
+  }
+
+  const handleDeleteCoupon = async (id, code) => {
+    if (!confirm(`"${code}" 쿠폰을 삭제하시겠습니까?`)) return
+    try {
+      await deleteCoupon(id)
+      setCoupons(prev => prev.filter(c => c.id !== id))
+    } catch (e) {
+      alert(e.message)
+      load()
+    }
+  }
+
   const handleCreateDiscount = async (payload) => {
     const d = await createDiscount(payload)
     setDiscounts(prev => [d, ...prev])
+  }
+
+  const handleToggleDiscount = async (id) => {
+    try {
+      const updated = await toggleDiscount(id)
+      setDiscounts(prev => prev.map(d => d.id === id ? updated : d))
+    } catch (e) { alert(e.message) }
+  }
+
+  const handleDeleteDiscount = async (id, name) => {
+    if (!confirm(`"${name}" 할인을 삭제하시겠습니까?`)) return
+    try {
+      await deleteDiscount(id)
+      setDiscounts(prev => prev.filter(d => d.id !== id))
+    } catch (e) { alert(e.message) }
   }
 
   const filteredCoupons   = coupons.filter(c =>
@@ -308,10 +351,11 @@ export default function CouponsPage() {
                   <th>사용/최대</th>
                   <th>유효기한</th>
                   <th>활성</th>
+                  <th></th>
                 </tr>
               </thead>
               <tbody>
-                {filteredCoupons.length === 0 && <tr><td colSpan={7} className="loading-text">쿠폰이 없습니다</td></tr>}
+                {filteredCoupons.length === 0 && <tr><td colSpan={8} className="loading-text">쿠폰이 없습니다</td></tr>}
                 {filteredCoupons.map(c => (
                   <tr key={c.id} style={{ color: c.is_active ? '#222' : '#bbb' }}>
                     <td style={{ fontWeight:'600', fontFamily:'monospace', letterSpacing:'0.5px' }}>{c.code}</td>
@@ -324,10 +368,15 @@ export default function CouponsPage() {
                     <td>{c.min_order_amount ? `${Number(c.min_order_amount).toLocaleString('ko-KR')}원` : '–'}</td>
                     <td>{c.used_count}/{c.max_usage_count || '∞'}</td>
                     <td style={{ fontSize:'13px', color:'#888' }}>{fmtDate(c.valid_until)}</td>
-                    <td>
-                      <span className={`badge ${c.is_active ? 'badge-active' : 'badge-inactive'}`}>
-                        {c.is_active ? '활성' : '비활성'}
-                      </span>
+                    <td onClick={e => e.stopPropagation()}>
+                      <Toggle checked={c.is_active} onChange={() => handleToggleCoupon(c.id)} />
+                    </td>
+                    <td onClick={e => e.stopPropagation()}>
+                      <button
+                        className="btn-sm"
+                        style={{ background:'#ffeaea', color:'#c00', border:'1px solid #ffc0c0', borderRadius:6, fontSize:12, padding:'4px 10px', cursor:'pointer' }}
+                        onClick={() => handleDeleteCoupon(c.id, c.code)}
+                      >삭제</button>
                     </td>
                   </tr>
                 ))}
@@ -359,10 +408,11 @@ export default function CouponsPage() {
                   <th>적용등급</th>
                   <th>유효기한</th>
                   <th>활성</th>
+                  <th></th>
                 </tr>
               </thead>
               <tbody>
-                {filteredDiscounts.length === 0 && <tr><td colSpan={7} className="loading-text">할인이 없습니다</td></tr>}
+                {filteredDiscounts.length === 0 && <tr><td colSpan={8} className="loading-text">할인이 없습니다</td></tr>}
                 {filteredDiscounts.map(d => (
                   <tr key={d.id} style={{ color: d.is_active ? '#222' : '#bbb' }}>
                     <td style={{ fontWeight:'500' }}>{d.name_ko}</td>
@@ -379,10 +429,15 @@ export default function CouponsPage() {
                     </td>
                     <td style={{ fontSize:'13px', color:'#888' }}>{TIER_LABELS[d.applicable_tier] ?? d.applicable_tier}</td>
                     <td style={{ fontSize:'13px', color:'#888' }}>{fmtDate(d.valid_until)}</td>
-                    <td>
-                      <span className={`badge ${d.is_active ? 'badge-active' : 'badge-inactive'}`}>
-                        {d.is_active ? '활성' : '비활성'}
-                      </span>
+                    <td onClick={e => e.stopPropagation()}>
+                      <Toggle checked={d.is_active} onChange={() => handleToggleDiscount(d.id)} />
+                    </td>
+                    <td onClick={e => e.stopPropagation()}>
+                      <button
+                        className="btn-sm"
+                        style={{ background:'#ffeaea', color:'#c00', border:'1px solid #ffc0c0', borderRadius:6, fontSize:12, padding:'4px 10px', cursor:'pointer' }}
+                        onClick={() => handleDeleteDiscount(d.id, d.name_ko)}
+                      >삭제</button>
                     </td>
                   </tr>
                 ))}

--- a/frontend/src/admin/pages/DashboardPage.jsx
+++ b/frontend/src/admin/pages/DashboardPage.jsx
@@ -6,7 +6,6 @@ function fmt(n) {
 }
 
 function shortDate(dateStr) {
-  // "YYYY-MM-DD" → "M/D"
   const [, m, d] = (dateStr ?? '').split('-')
   return m && d ? `${parseInt(m)}/${parseInt(d)}` : dateStr
 }
@@ -65,8 +64,70 @@ function BarChart({ data }) {
   )
 }
 
+function LineChart({ data }) {
+  const max = Math.max(...data.map(d => d.sales), 1)
+  const W = 600
+  const H = 160
+  const PAD_L = 50
+  const PAD_R = 16
+  const PAD_T = 12
+  const PAD_B = 28
+  const innerW = W - PAD_L - PAD_R
+  const innerH = H - PAD_T - PAD_B
+
+  if (data.length < 2) return <BarChart data={data} />
+
+  const px = (i) => PAD_L + (i / (data.length - 1)) * innerW
+  const py = (v) => PAD_T + (1 - v / max) * innerH
+
+  const points = data.map((d, i) => `${px(i)},${py(d.sales)}`).join(' ')
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} width="100%" height={H + 8} style={{ overflow: 'visible' }}>
+      {/* Y축 그리드 */}
+      {[0, 0.25, 0.5, 0.75, 1].map(ratio => {
+        const y = PAD_T + (1 - ratio) * innerH
+        return (
+          <g key={ratio}>
+            <line x1={PAD_L} y1={y} x2={W - PAD_R} y2={y} stroke="#f0f0f0" strokeWidth="1" />
+            <text x={PAD_L - 6} y={y + 4} textAnchor="end" fontSize="9" fill="#bbb">
+              {fmt(max * ratio)}
+            </text>
+          </g>
+        )
+      })}
+      {/* 영역 채우기 */}
+      <polygon
+        points={`${PAD_L},${PAD_T + innerH} ${points} ${px(data.length - 1)},${PAD_T + innerH}`}
+        fill="#744032"
+        fillOpacity="0.08"
+      />
+      {/* 선 */}
+      <polyline points={points} fill="none" stroke="#744032" strokeWidth="2.5" strokeLinejoin="round" strokeLinecap="round" />
+      {/* 점 + 날짜 */}
+      {data.map((d, i) => (
+        <g key={i}>
+          <circle
+            cx={px(i)} cy={py(d.sales)} r="4"
+            fill={i === data.length - 1 ? '#744032' : '#fff'}
+            stroke="#744032" strokeWidth="2"
+          />
+          <title>{shortDate(d.date)}: {fmt(d.sales)}원</title>
+          {(i === 0 || i === data.length - 1 || i % Math.ceil(data.length / 8) === 0) && (
+            <text x={px(i)} y={H - 4} textAnchor="middle" fontSize="9" fill="#999">
+              {shortDate(d.date)}
+            </text>
+          )}
+        </g>
+      ))}
+    </svg>
+  )
+}
+
 export default function DashboardPage() {
   const [range, setRange]               = useState('7d')
+  // 7일 기본 Bar, 30일 기본 Line — range 변경 시 자동 전환
+  const [chartType, setChartType]       = useState('bar')
   const [summary, setSummary]           = useState(null)
   const [salesData, setSalesData]       = useState([])
   const [popular, setPopular]           = useState([])
@@ -74,6 +135,12 @@ export default function DashboardPage() {
   const [paymentStats, setPaymentStats] = useState([])
   const [loading, setLoading]           = useState(true)
   const [error, setError]               = useState('')
+
+  const handleRangeChange = (r) => {
+    setRange(r)
+    // 30일→Line, 7일→Bar 기본 전환
+    setChartType(r === '30d' ? 'line' : 'bar')
+  }
 
   useEffect(() => {
     setLoading(true)
@@ -96,18 +163,24 @@ export default function DashboardPage() {
       .finally(() => setLoading(false))
   }, [range])
 
-  if (loading) return <div className="loading-text">통계 로딩 중…</div>
+  if (loading) return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', minHeight: 300, gap: 20 }}>
+      <img src="/logo.png" alt="로고" style={{ height: 64, objectFit: 'contain' }} />
+      <div className="loading-text">통계 로딩 중…</div>
+    </div>
+  )
   if (error)   return <div className="loading-text" style={{ color:'#c00' }}>{error}</div>
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
-      {/* Period toggle */}
-      <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+      {/* 로고 + Period toggle */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <img src="/logo.png" alt="로고" style={{ height: 48, objectFit: 'contain' }} />
         <div style={{ display: 'flex', borderRadius: '8px', overflow: 'hidden', border: '1.5px solid #ddd' }}>
           {['7d', '30d'].map(r => (
             <button
               key={r}
-              onClick={() => setRange(r)}
+              onClick={() => handleRangeChange(r)}
               style={{
                 padding: '6px 20px', fontSize: '13px', fontWeight: '600',
                 border: 'none', cursor: 'pointer', fontFamily: 'Pretendard, sans-serif',
@@ -137,11 +210,35 @@ export default function DashboardPage() {
 
       {/* Sales chart */}
       <div className="card">
-        <div style={{ fontWeight: '600', fontSize: '15px', marginBottom: '20px' }}>
-          최근 {range === '7d' ? '7일' : '30일'} 매출 추이
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '20px' }}>
+          <span style={{ fontWeight: '600', fontSize: '15px' }}>
+            최근 {range === '7d' ? '7일' : '30일'} 매출 추이
+          </span>
+          {/* Bar / Line 전환 토글 */}
+          <div style={{ display: 'flex', borderRadius: 6, overflow: 'hidden', border: '1.5px solid #e0e0e0' }}>
+            {[
+              { key: 'bar',  label: '막대' },
+              { key: 'line', label: '선형' },
+            ].map(({ key, label }) => (
+              <button
+                key={key}
+                onClick={() => setChartType(key)}
+                style={{
+                  padding: '4px 14px', fontSize: '12px', fontWeight: '600',
+                  border: 'none', cursor: 'pointer', fontFamily: 'Pretendard, sans-serif',
+                  background: chartType === key ? '#744032' : '#fff',
+                  color:      chartType === key ? '#fff'    : '#888',
+                }}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
         </div>
         {salesData.length > 0
-          ? <BarChart data={salesData} />
+          ? (chartType === 'bar'
+              ? <BarChart data={salesData} />
+              : <LineChart data={salesData} />)
           : <div className="loading-text">데이터가 없습니다</div>
         }
       </div>

--- a/frontend/src/admin/pages/DashboardPage.jsx
+++ b/frontend/src/admin/pages/DashboardPage.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { fetchStatsSummary, fetchSalesSeries, fetchPopularItems } from '../api/adminApi.js'
+import { fetchStatsSummary, fetchSalesSeries, fetchPopularItems, fetchCategorySales, fetchPaymentMethodStats } from '../api/adminApi.js'
 
 function fmt(n) {
   return Math.round(n).toLocaleString('ko-KR')
@@ -9,6 +9,31 @@ function shortDate(dateStr) {
   // "YYYY-MM-DD" → "M/D"
   const [, m, d] = (dateStr ?? '').split('-')
   return m && d ? `${parseInt(m)}/${parseInt(d)}` : dateStr
+}
+
+function CategorySalesChart({ data }) {
+  const max = Math.max(...data.map(d => d.revenue), 1)
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+      {data.map(item => (
+        <div key={item.category_id}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, marginBottom: 5 }}>
+            <span style={{ fontWeight: 500 }}>{item.name_ko}</span>
+            <span style={{ color: '#744032', fontWeight: 600 }}>
+              {item.ratio}% &nbsp;·&nbsp; {fmt(item.revenue)}원
+            </span>
+          </div>
+          <div style={{ background: '#f5f5f5', borderRadius: 4, height: 8 }}>
+            <div style={{
+              width: `${(item.revenue / max) * 100}%`,
+              background: '#744032', borderRadius: 4, height: '100%',
+              transition: 'width 0.4s',
+            }} />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
 }
 
 function BarChart({ data }) {
@@ -41,12 +66,14 @@ function BarChart({ data }) {
 }
 
 export default function DashboardPage() {
-  const [range, setRange] = useState('7d')
-  const [summary, setSummary]     = useState(null)
-  const [salesData, setSalesData] = useState([])
-  const [popular, setPopular]     = useState([])
-  const [loading, setLoading]     = useState(true)
-  const [error, setError]         = useState('')
+  const [range, setRange]               = useState('7d')
+  const [summary, setSummary]           = useState(null)
+  const [salesData, setSalesData]       = useState([])
+  const [popular, setPopular]           = useState([])
+  const [categorySales, setCategorySales] = useState([])
+  const [paymentStats, setPaymentStats] = useState([])
+  const [loading, setLoading]           = useState(true)
+  const [error, setError]               = useState('')
 
   useEffect(() => {
     setLoading(true)
@@ -55,11 +82,15 @@ export default function DashboardPage() {
       fetchStatsSummary(),
       fetchSalesSeries(range),
       fetchPopularItems(range),
+      fetchCategorySales(range),
+      fetchPaymentMethodStats(range),
     ])
-      .then(([sum, sales, pop]) => {
+      .then(([sum, sales, pop, cats, pmts]) => {
         setSummary(sum)
         setSalesData(sales.data ?? [])
         setPopular(pop)
+        setCategorySales(cats)
+        setPaymentStats(pmts)
       })
       .catch(e => setError(e.message))
       .finally(() => setLoading(false))
@@ -139,6 +170,43 @@ export default function DashboardPage() {
                     <td style={{ fontWeight: '500' }}>{item.name_ko}</td>
                     <td style={{ textAlign: 'right' }}>{fmt(item.quantity_sold)}개</td>
                     <td style={{ textAlign: 'right', fontWeight: '600' }}>{fmt(item.revenue)}원</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )
+        }
+      </div>
+
+      {/* Category sales */}
+      <div className="card">
+        <div style={{ fontWeight: '600', fontSize: '15px', marginBottom: '16px' }}>카테고리별 매출 비율</div>
+        {categorySales.length === 0
+          ? <div className="loading-text">데이터가 없습니다</div>
+          : <CategorySalesChart data={categorySales} />
+        }
+      </div>
+
+      {/* Payment method stats */}
+      <div className="card">
+        <div style={{ fontWeight: '600', fontSize: '15px', marginBottom: '16px' }}>결제수단별 집계</div>
+        {paymentStats.length === 0
+          ? <div className="loading-text">데이터가 없습니다</div>
+          : (
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th>결제수단</th>
+                  <th style={{ textAlign: 'right' }}>건수</th>
+                  <th style={{ textAlign: 'right' }}>합계</th>
+                </tr>
+              </thead>
+              <tbody>
+                {paymentStats.map(p => (
+                  <tr key={p.method}>
+                    <td style={{ fontWeight: 500 }}>{p.method}</td>
+                    <td style={{ textAlign: 'right' }}>{fmt(p.count)}건</td>
+                    <td style={{ textAlign: 'right', fontWeight: 600 }}>{fmt(p.total_amount)}원</td>
                   </tr>
                 ))}
               </tbody>

--- a/frontend/src/admin/pages/DashboardPage.jsx
+++ b/frontend/src/admin/pages/DashboardPage.jsx
@@ -66,14 +66,15 @@ function BarChart({ data }) {
 
 function LineChart({ data }) {
   const max = Math.max(...data.map(d => d.sales), 1)
-  const W = 600
-  const H = 160
-  const PAD_L = 50
+  // 고정 좌표계(viewBox)를 사용하되 width="100%"로 카드 전체를 채움
+  const VW = 1000
+  const VH = 200
+  const PAD_L = 72
   const PAD_R = 16
-  const PAD_T = 12
-  const PAD_B = 28
-  const innerW = W - PAD_L - PAD_R
-  const innerH = H - PAD_T - PAD_B
+  const PAD_T = 16
+  const PAD_B = 36
+  const innerW = VW - PAD_L - PAD_R
+  const innerH = VH - PAD_T - PAD_B
 
   if (data.length < 2) return <BarChart data={data} />
 
@@ -83,14 +84,19 @@ function LineChart({ data }) {
   const points = data.map((d, i) => `${px(i)},${py(d.sales)}`).join(' ')
 
   return (
-    <svg viewBox={`0 0 ${W} ${H}`} width="100%" height={H + 8} style={{ overflow: 'visible' }}>
+    <svg
+      viewBox={`0 0 ${VW} ${VH}`}
+      width="100%"
+      style={{ display: 'block', overflow: 'visible' }}
+      preserveAspectRatio="none"
+    >
       {/* Y축 그리드 */}
       {[0, 0.25, 0.5, 0.75, 1].map(ratio => {
         const y = PAD_T + (1 - ratio) * innerH
         return (
           <g key={ratio}>
-            <line x1={PAD_L} y1={y} x2={W - PAD_R} y2={y} stroke="#f0f0f0" strokeWidth="1" />
-            <text x={PAD_L - 6} y={y + 4} textAnchor="end" fontSize="9" fill="#bbb">
+            <line x1={PAD_L} y1={y} x2={VW - PAD_R} y2={y} stroke="#f0f0f0" strokeWidth="1" />
+            <text x={PAD_L - 8} y={y + 4} textAnchor="end" fontSize="14" fill="#bbb">
               {fmt(max * ratio)}
             </text>
           </g>
@@ -103,18 +109,18 @@ function LineChart({ data }) {
         fillOpacity="0.08"
       />
       {/* 선 */}
-      <polyline points={points} fill="none" stroke="#744032" strokeWidth="2.5" strokeLinejoin="round" strokeLinecap="round" />
+      <polyline points={points} fill="none" stroke="#744032" strokeWidth="3" strokeLinejoin="round" strokeLinecap="round" />
       {/* 점 + 날짜 */}
       {data.map((d, i) => (
         <g key={i}>
           <circle
-            cx={px(i)} cy={py(d.sales)} r="4"
+            cx={px(i)} cy={py(d.sales)} r="5"
             fill={i === data.length - 1 ? '#744032' : '#fff'}
-            stroke="#744032" strokeWidth="2"
+            stroke="#744032" strokeWidth="2.5"
           />
           <title>{shortDate(d.date)}: {fmt(d.sales)}원</title>
-          {(i === 0 || i === data.length - 1 || i % Math.ceil(data.length / 8) === 0) && (
-            <text x={px(i)} y={H - 4} textAnchor="middle" fontSize="9" fill="#999">
+          {(i === 0 || i === data.length - 1 || i % Math.ceil(data.length / 10) === 0) && (
+            <text x={px(i)} y={VH - 6} textAnchor="middle" fontSize="13" fill="#999">
               {shortDate(d.date)}
             </text>
           )}
@@ -163,19 +169,13 @@ export default function DashboardPage() {
       .finally(() => setLoading(false))
   }, [range])
 
-  if (loading) return (
-    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', minHeight: 300, gap: 20 }}>
-      <img src="/logo.png" alt="로고" style={{ height: 64, objectFit: 'contain' }} />
-      <div className="loading-text">통계 로딩 중…</div>
-    </div>
-  )
+  if (loading) return <div className="loading-text">통계 로딩 중…</div>
   if (error)   return <div className="loading-text" style={{ color:'#c00' }}>{error}</div>
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
-      {/* 로고 + Period toggle */}
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-        <img src="/logo.png" alt="로고" style={{ height: 48, objectFit: 'contain' }} />
+      {/* Period toggle */}
+      <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
         <div style={{ display: 'flex', borderRadius: '8px', overflow: 'hidden', border: '1.5px solid #ddd' }}>
           {['7d', '30d'].map(r => (
             <button

--- a/frontend/src/admin/pages/DashboardPage.jsx
+++ b/frontend/src/admin/pages/DashboardPage.jsx
@@ -1,0 +1,118 @@
+import { useState } from 'react'
+import { DUMMY_STATS } from '../api/adminApi.js'
+
+function fmt(n) {
+  return n.toLocaleString('ko-KR')
+}
+
+function BarChart({ data }) {
+  const max = Math.max(...data.map(d => d.sales), 1)
+  const CHART_H = 160
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'flex-end', gap: '8px', height: CHART_H + 28, padding: '0 4px' }}>
+      {data.map((d, i) => {
+        const barH = Math.round((d.sales / max) * CHART_H)
+        const isLast = i === data.length - 1
+        return (
+          <div key={i} style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '4px' }}>
+            <div
+              title={`${d.date}: ${fmt(d.sales)}원`}
+              style={{
+                width: '100%',
+                height: barH,
+                background: isLast ? '#744032' : '#F5B800',
+                borderRadius: '4px 4px 0 0',
+                transition: 'height 0.3s',
+              }}
+            />
+            <span style={{ fontSize: '11px', color: '#999', whiteSpace: 'nowrap' }}>{d.date}</span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export default function DashboardPage() {
+  const [range, setRange] = useState('7d')
+  const stats = DUMMY_STATS
+  const salesData = range === '7d' ? stats.sales_7d : stats.sales_30d
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+      {/* Period toggle */}
+      <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <div style={{ display: 'flex', borderRadius: '8px', overflow: 'hidden', border: '1.5px solid #ddd' }}>
+          {['7d', '30d'].map(r => (
+            <button
+              key={r}
+              onClick={() => setRange(r)}
+              style={{
+                padding: '6px 20px',
+                fontSize: '13px',
+                fontWeight: '600',
+                border: 'none',
+                background: range === r ? '#744032' : '#fff',
+                color: range === r ? '#fff' : '#555',
+                cursor: 'pointer',
+                fontFamily: 'Pretendard, sans-serif',
+              }}
+            >
+              {r === '7d' ? '7일' : '30일'}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Stat cards */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '16px' }}>
+        {[
+          { label: '오늘 매출 합계', value: `${fmt(stats.summary.today_sales)}원`, color: '#744032' },
+          { label: '오늘 주문 건수', value: `${fmt(stats.summary.order_count)}건`, color: '#744032' },
+          { label: '평균 객단가',    value: `${fmt(stats.summary.avg_order_value)}원`, color: '#744032' },
+        ].map(card => (
+          <div key={card.label} className="card">
+            <div style={{ fontSize: '13px', color: '#999', marginBottom: '10px' }}>{card.label}</div>
+            <div style={{ fontSize: '26px', fontWeight: '700', color: card.color }}>{card.value}</div>
+          </div>
+        ))}
+      </div>
+
+      {/* Sales chart */}
+      <div className="card">
+        <div style={{ fontWeight: '600', fontSize: '15px', marginBottom: '20px' }}>
+          최근 {range === '7d' ? '7일' : '30일'} 매출 추이
+        </div>
+        <BarChart data={salesData} />
+      </div>
+
+      {/* Popular items */}
+      <div className="card">
+        <div style={{ fontWeight: '600', fontSize: '15px', marginBottom: '16px' }}>인기 메뉴 랭킹</div>
+        <table className="data-table">
+          <thead>
+            <tr>
+              <th style={{ width: 48 }}>순위</th>
+              <th>메뉴명</th>
+              <th style={{ textAlign: 'right' }}>판매수량</th>
+              <th style={{ textAlign: 'right' }}>매출</th>
+            </tr>
+          </thead>
+          <tbody>
+            {stats.popular_items.map((item, i) => (
+              <tr key={item.menu_item_id}>
+                <td style={{ color: i < 3 ? '#744032' : '#999', fontWeight: i < 3 ? '700' : '400' }}>
+                  {i + 1}
+                </td>
+                <td style={{ fontWeight: '500' }}>{item.name_ko}</td>
+                <td style={{ textAlign: 'right' }}>{fmt(item.quantity_sold)}개</td>
+                <td style={{ textAlign: 'right', fontWeight: '600' }}>{fmt(item.revenue)}원</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/admin/pages/DashboardPage.jsx
+++ b/frontend/src/admin/pages/DashboardPage.jsx
@@ -1,8 +1,14 @@
-import { useState } from 'react'
-import { DUMMY_STATS } from '../api/adminApi.js'
+import { useState, useEffect } from 'react'
+import { fetchStatsSummary, fetchSalesSeries, fetchPopularItems } from '../api/adminApi.js'
 
 function fmt(n) {
-  return n.toLocaleString('ko-KR')
+  return Math.round(n).toLocaleString('ko-KR')
+}
+
+function shortDate(dateStr) {
+  // "YYYY-MM-DD" → "M/D"
+  const [, m, d] = (dateStr ?? '').split('-')
+  return m && d ? `${parseInt(m)}/${parseInt(d)}` : dateStr
 }
 
 function BarChart({ data }) {
@@ -17,7 +23,7 @@ function BarChart({ data }) {
         return (
           <div key={i} style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '4px' }}>
             <div
-              title={`${d.date}: ${fmt(d.sales)}원`}
+              title={`${shortDate(d.date)}: ${fmt(d.sales)}원`}
               style={{
                 width: '100%',
                 height: barH,
@@ -26,7 +32,7 @@ function BarChart({ data }) {
                 transition: 'height 0.3s',
               }}
             />
-            <span style={{ fontSize: '11px', color: '#999', whiteSpace: 'nowrap' }}>{d.date}</span>
+            <span style={{ fontSize: '11px', color: '#999', whiteSpace: 'nowrap' }}>{shortDate(d.date)}</span>
           </div>
         )
       })}
@@ -36,8 +42,31 @@ function BarChart({ data }) {
 
 export default function DashboardPage() {
   const [range, setRange] = useState('7d')
-  const stats = DUMMY_STATS
-  const salesData = range === '7d' ? stats.sales_7d : stats.sales_30d
+  const [summary, setSummary]     = useState(null)
+  const [salesData, setSalesData] = useState([])
+  const [popular, setPopular]     = useState([])
+  const [loading, setLoading]     = useState(true)
+  const [error, setError]         = useState('')
+
+  useEffect(() => {
+    setLoading(true)
+    setError('')
+    Promise.all([
+      fetchStatsSummary(),
+      fetchSalesSeries(range),
+      fetchPopularItems(range),
+    ])
+      .then(([sum, sales, pop]) => {
+        setSummary(sum)
+        setSalesData(sales.data ?? [])
+        setPopular(pop)
+      })
+      .catch(e => setError(e.message))
+      .finally(() => setLoading(false))
+  }, [range])
+
+  if (loading) return <div className="loading-text">통계 로딩 중…</div>
+  if (error)   return <div className="loading-text" style={{ color:'#c00' }}>{error}</div>
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
@@ -49,14 +78,10 @@ export default function DashboardPage() {
               key={r}
               onClick={() => setRange(r)}
               style={{
-                padding: '6px 20px',
-                fontSize: '13px',
-                fontWeight: '600',
-                border: 'none',
+                padding: '6px 20px', fontSize: '13px', fontWeight: '600',
+                border: 'none', cursor: 'pointer', fontFamily: 'Pretendard, sans-serif',
                 background: range === r ? '#744032' : '#fff',
-                color: range === r ? '#fff' : '#555',
-                cursor: 'pointer',
-                fontFamily: 'Pretendard, sans-serif',
+                color:      range === r ? '#fff'    : '#555',
               }}
             >
               {r === '7d' ? '7일' : '30일'}
@@ -68,13 +93,13 @@ export default function DashboardPage() {
       {/* Stat cards */}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '16px' }}>
         {[
-          { label: '오늘 매출 합계', value: `${fmt(stats.summary.today_sales)}원`, color: '#744032' },
-          { label: '오늘 주문 건수', value: `${fmt(stats.summary.order_count)}건`, color: '#744032' },
-          { label: '평균 객단가',    value: `${fmt(stats.summary.avg_order_value)}원`, color: '#744032' },
+          { label: '오늘 매출 합계', value: `${fmt(summary?.today_sales ?? 0)}원` },
+          { label: '오늘 주문 건수', value: `${fmt(summary?.order_count ?? 0)}건` },
+          { label: '평균 객단가',    value: `${fmt(summary?.avg_order_value ?? 0)}원` },
         ].map(card => (
           <div key={card.label} className="card">
             <div style={{ fontSize: '13px', color: '#999', marginBottom: '10px' }}>{card.label}</div>
-            <div style={{ fontSize: '26px', fontWeight: '700', color: card.color }}>{card.value}</div>
+            <div style={{ fontSize: '26px', fontWeight: '700', color: '#744032' }}>{card.value}</div>
           </div>
         ))}
       </div>
@@ -84,34 +109,42 @@ export default function DashboardPage() {
         <div style={{ fontWeight: '600', fontSize: '15px', marginBottom: '20px' }}>
           최근 {range === '7d' ? '7일' : '30일'} 매출 추이
         </div>
-        <BarChart data={salesData} />
+        {salesData.length > 0
+          ? <BarChart data={salesData} />
+          : <div className="loading-text">데이터가 없습니다</div>
+        }
       </div>
 
       {/* Popular items */}
       <div className="card">
         <div style={{ fontWeight: '600', fontSize: '15px', marginBottom: '16px' }}>인기 메뉴 랭킹</div>
-        <table className="data-table">
-          <thead>
-            <tr>
-              <th style={{ width: 48 }}>순위</th>
-              <th>메뉴명</th>
-              <th style={{ textAlign: 'right' }}>판매수량</th>
-              <th style={{ textAlign: 'right' }}>매출</th>
-            </tr>
-          </thead>
-          <tbody>
-            {stats.popular_items.map((item, i) => (
-              <tr key={item.menu_item_id}>
-                <td style={{ color: i < 3 ? '#744032' : '#999', fontWeight: i < 3 ? '700' : '400' }}>
-                  {i + 1}
-                </td>
-                <td style={{ fontWeight: '500' }}>{item.name_ko}</td>
-                <td style={{ textAlign: 'right' }}>{fmt(item.quantity_sold)}개</td>
-                <td style={{ textAlign: 'right', fontWeight: '600' }}>{fmt(item.revenue)}원</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        {popular.length === 0
+          ? <div className="loading-text">데이터가 없습니다</div>
+          : (
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th style={{ width: 48 }}>순위</th>
+                  <th>메뉴명</th>
+                  <th style={{ textAlign: 'right' }}>판매수량</th>
+                  <th style={{ textAlign: 'right' }}>매출</th>
+                </tr>
+              </thead>
+              <tbody>
+                {popular.map((item, i) => (
+                  <tr key={item.menu_item_id}>
+                    <td style={{ color: i < 3 ? '#744032' : '#999', fontWeight: i < 3 ? '700' : '400' }}>
+                      {i + 1}
+                    </td>
+                    <td style={{ fontWeight: '500' }}>{item.name_ko}</td>
+                    <td style={{ textAlign: 'right' }}>{fmt(item.quantity_sold)}개</td>
+                    <td style={{ textAlign: 'right', fontWeight: '600' }}>{fmt(item.revenue)}원</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )
+        }
       </div>
     </div>
   )

--- a/frontend/src/admin/pages/LoginPage.jsx
+++ b/frontend/src/admin/pages/LoginPage.jsx
@@ -1,0 +1,109 @@
+import { useState } from 'react'
+
+export default function LoginPage({ onLogin }) {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    if (!username || !password) { setError('아이디와 비밀번호를 입력해 주세요'); return }
+    setError('')
+    setLoading(true)
+    try {
+      await onLogin(username, password)
+    } catch (err) {
+      setError(err.message ?? '아이디 또는 비밀번호가 올바르지 않습니다')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div style={{
+      minHeight: '100vh',
+      background: '#f5f5f5',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      fontFamily: 'Pretendard, sans-serif',
+    }}>
+      <div style={{
+        background: '#fff',
+        borderRadius: '16px',
+        padding: '48px 52px',
+        width: '460px',
+        boxShadow: '0 2px 16px rgba(0,0,0,0.08)',
+      }}>
+        {/* Logo */}
+        <div style={{ textAlign: 'center', marginBottom: '36px' }}>
+          <div style={{ color: '#F5B800', fontSize: '28px', fontWeight: '700', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '8px' }}>
+            <span style={{ fontSize: '32px' }}>🍔</span>
+            <span style={{ letterSpacing: '2px' }}>BURGER</span>
+          </div>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <div className="form-group">
+            <label className="form-label">아이디</label>
+            <input
+              className="form-input"
+              type="text"
+              value={username}
+              onChange={e => setUsername(e.target.value)}
+              autoComplete="username"
+              autoFocus
+            />
+          </div>
+
+          <div className="form-group" style={{ marginBottom: '8px' }}>
+            <label className="form-label">비밀번호</label>
+            <input
+              className="form-input"
+              type="password"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              autoComplete="current-password"
+            />
+          </div>
+
+          {error && (
+            <div style={{
+              color: '#c0392b',
+              fontSize: '13px',
+              marginBottom: '12px',
+              padding: '8px 12px',
+              background: '#fde8e8',
+              borderRadius: '6px',
+            }}>
+              {error}
+            </div>
+          )}
+
+          <div style={{ marginTop: '28px' }}>
+            <button
+              type="submit"
+              disabled={loading}
+              style={{
+                width: '100%',
+                padding: '15px',
+                background: '#744032',
+                color: '#fff',
+                border: 'none',
+                borderRadius: '10px',
+                fontSize: '16px',
+                fontWeight: '700',
+                cursor: loading ? 'not-allowed' : 'pointer',
+                opacity: loading ? 0.7 : 1,
+                fontFamily: 'Pretendard, sans-serif',
+              }}
+            >
+              {loading ? '로그인 중…' : '로그인'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/admin/pages/MenuPage.jsx
+++ b/frontend/src/admin/pages/MenuPage.jsx
@@ -21,11 +21,11 @@ function Toggle({ checked, onChange }) {
     <div
       role="switch"
       aria-checked={checked}
-      className="toggle"
+      className={`toggle${checked ? ' checked' : ''}`}
       onClick={e => { e.stopPropagation(); onChange(!checked) }}
-      style={{ cursor: 'pointer', display: 'inline-flex', alignItems: 'center' }}
+      style={{ cursor: 'pointer' }}
     >
-      <div className="toggle-track" style={{ background: checked ? '#744032' : '#ccc' }} />
+      <div className="toggle-track" />
       <div className="toggle-thumb" />
     </div>
   )

--- a/frontend/src/admin/pages/MenuPage.jsx
+++ b/frontend/src/admin/pages/MenuPage.jsx
@@ -1,8 +1,8 @@
 import { useRef, useState, useEffect } from 'react'
 import {
   fetchAdminMenu,
-  updateMenuItem, createMenuItem,
-  updateCategory,
+  updateMenuItem, createMenuItem, deleteMenuItem,
+  createCategory, updateCategory, deleteCategory,
   createMenuOption, updateMenuOption, deleteMenuOption,
   uploadMenuImage,
 } from '../api/adminApi.js'
@@ -81,6 +81,56 @@ function ImageUploader({ url, onChange }) {
           </button>
           <input ref={fileRef} type="file" accept="image/*" style={{ display: 'none' }} onChange={handleFile} />
           {error && <div style={{ color: '#c00', fontSize: 12, marginTop: 4 }}>{error}</div>}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ─── EditCategoryModal ─────────────────────────────────────────────────────
+function EditCategoryModal({ onClose, onSave }) {
+  const [form, setForm] = useState({ name_ko: '', name_en: '', display_order: 0 })
+  const [loading, setLoading] = useState(false)
+  const set = (k, v) => setForm(f => ({ ...f, [k]: v }))
+
+  const handleSave = async () => {
+    if (!form.name_ko.trim()) { alert('한국어 이름을 입력하세요'); return }
+    if (!form.name_en.trim()) { alert('영어 이름을 입력하세요'); return }
+    setLoading(true)
+    try {
+      await onSave({ ...form, display_order: Number(form.display_order), is_visible: true })
+      onClose()
+    } catch (e) {
+      alert(e.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-box" style={{ width: 400 }}>
+        <div className="modal-title">카테고리 추가</div>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginBottom: 12 }}>
+          <div className="form-group" style={{ marginBottom: 0 }}>
+            <label className="form-label">이름 (한국어) *</label>
+            <input className="form-input" value={form.name_ko} onChange={e => set('name_ko', e.target.value)} autoFocus />
+          </div>
+          <div className="form-group" style={{ marginBottom: 0 }}>
+            <label className="form-label">이름 (영어) *</label>
+            <input className="form-input" value={form.name_en} onChange={e => set('name_en', e.target.value)} />
+          </div>
+        </div>
+        <div className="form-group">
+          <label className="form-label">표시 순서</label>
+          <input className="form-input" type="number" min="0" value={form.display_order}
+            onChange={e => set('display_order', e.target.value)} />
+        </div>
+        <div className="modal-footer">
+          <button className="btn-outline" onClick={onClose}>취소</button>
+          <button className="btn-primary" onClick={handleSave} disabled={loading}>
+            {loading ? '저장 중…' : '추가'}
+          </button>
         </div>
       </div>
     </div>
@@ -269,7 +319,10 @@ export default function MenuPage() {
   const [selectedItem, setSelectedItem] = useState(null)
   const [editItem,     setEditItem]     = useState(undefined)   // undefined=hidden | null=new | obj=edit
   const [editOption,   setEditOption]   = useState(undefined)   // undefined=hidden | null=new | obj=edit
+  const [editCat,      setEditCat]      = useState(false)        // false=hidden | true=show
   const [deletingOpt,  setDeletingOpt]  = useState(null)
+  const [deletingItem, setDeletingItem] = useState(null)
+  const [deletingCat,  setDeletingCat]  = useState(null)
 
   const load = () => {
     setLoading(true)
@@ -313,6 +366,39 @@ export default function MenuPage() {
     finally { setDeletingOpt(null) }
   }
 
+  const handleDeleteItem = async (itemId) => {
+    setDeletingItem(itemId)
+    try {
+      await deleteMenuItem(itemId)
+      if (selectedItem === itemId) setSelectedItem(null)
+    } catch (e) {
+      alert(e.message)
+    } finally {
+      setDeletingItem(null)
+      load()
+    }
+  }
+
+  const handleSaveCat = async (payload) => {
+    await createCategory(payload)
+    load()
+  }
+
+  const handleDeleteCat = async (cat) => {
+    if (!confirm(`"${cat.name_ko}" 카테고리를 삭제하시겠습니까?\n메뉴가 있으면 삭제되지 않습니다.`)) return
+    setDeletingCat(cat.id)
+    try {
+      await deleteCategory(cat.id)
+      if (selectedCat === cat.id) setSelectedCat(null)
+      load()
+    } catch (e) {
+      alert(e.message)
+      load()
+    } finally {
+      setDeletingCat(null)
+    }
+  }
+
   const handleToggleOptionAvailable = async (item, opt) => {
     try { await updateMenuOption(item.id, opt.id, { is_available: !opt.is_available }); load() }
     catch (e) { alert(e.message) }
@@ -339,27 +425,44 @@ export default function MenuPage() {
 
       {/* ── 카테고리 패널 ── */}
       <div className="card" style={{ width: 180, minWidth: 180, padding: '8px 0' }}>
-        <div style={{ padding: '12px 16px 8px', fontWeight: 700, fontSize: 14 }}>카테고리</div>
+        <div style={{ padding: '12px 16px 8px', fontWeight: 700, fontSize: 14, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <span>카테고리</span>
+          <button
+            className="btn-primary"
+            style={{ fontSize: 11, padding: '3px 8px', borderRadius: 6 }}
+            onClick={() => setEditCat(true)}
+          >+ 추가</button>
+        </div>
         {(data?.categories ?? []).map(cat => (
           <div
             key={cat.id}
             onClick={() => { setSelectedCat(cat.id); setSelectedItem(null) }}
             style={{
-              padding: '10px 16px', cursor: 'pointer',
+              padding: '8px 16px', cursor: 'pointer',
               display: 'flex', alignItems: 'center', justifyContent: 'space-between',
               background:   selectedCat === cat.id ? '#fff5f0' : 'transparent',
               borderLeft:   selectedCat === cat.id ? '3px solid #744032' : '3px solid transparent',
               fontWeight:   selectedCat === cat.id ? 600 : 400,
             }}
           >
-            <span style={{ fontSize: 14 }}>{cat.name_ko}</span>
-            <span
-              className={`badge ${cat.is_visible ? 'badge-active' : 'badge-inactive'}`}
-              style={{ fontSize: 10, padding: '1px 7px', cursor: 'pointer' }}
-              onClick={e => { e.stopPropagation(); handleToggleCatVisible(cat) }}
-            >
-              {cat.is_visible ? '노출' : '숨김'}
-            </span>
+            <span style={{ fontSize: 14, flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{cat.name_ko}</span>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexShrink: 0 }} onClick={e => e.stopPropagation()}>
+              <span
+                className={`badge ${cat.is_visible ? 'badge-active' : 'badge-inactive'}`}
+                style={{ fontSize: 10, padding: '1px 7px', cursor: 'pointer' }}
+                onClick={() => handleToggleCatVisible(cat)}
+              >
+                {cat.is_visible ? '노출' : '숨김'}
+              </span>
+              <button
+                style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#bbb', fontSize: 14, lineHeight: 1, padding: '0 2px' }}
+                disabled={deletingCat === cat.id}
+                onClick={() => handleDeleteCat(cat)}
+                title="삭제"
+              >
+                {deletingCat === cat.id ? '…' : '✕'}
+              </button>
+            </div>
           </div>
         ))}
       </div>
@@ -379,7 +482,7 @@ export default function MenuPage() {
                 <th>가격</th>
                 <th>품절여부</th>
                 <th>상태</th>
-                <th style={{ width: 60 }}>수정</th>
+                <th style={{ width: 110 }}>수정/삭제</th>
               </tr>
             </thead>
             <tbody>
@@ -412,7 +515,20 @@ export default function MenuPage() {
                     </div>
                   </td>
                   <td onClick={e => e.stopPropagation()}>
-                    <button className="btn-outline btn-sm" onClick={() => setEditItem(item)}>수정</button>
+                    <div style={{ display: 'flex', gap: 4 }}>
+                      <button className="btn-outline btn-sm" onClick={() => setEditItem(item)}>수정</button>
+                      <button
+                        className="btn-sm"
+                        style={{ background: '#ffeaea', color: '#c00', border: '1px solid #ffc0c0', borderRadius: 6, fontSize: 12, padding: '4px 8px', cursor: 'pointer' }}
+                        disabled={deletingItem === item.id}
+                        onClick={() => {
+                          if (confirm(`"${item.name_ko}"을(를) 삭제하시겠습니까?\n진행 중인 주문이 있으면 품절 처리됩니다.`))
+                            handleDeleteItem(item.id)
+                        }}
+                      >
+                        {deletingItem === item.id ? '…' : '삭제'}
+                      </button>
+                    </div>
                   </td>
                 </tr>
               ))}
@@ -494,6 +610,13 @@ export default function MenuPage() {
       </div>
 
       {/* ── 모달 ── */}
+      {editCat && (
+        <EditCategoryModal
+          onClose={() => setEditCat(false)}
+          onSave={handleSaveCat}
+        />
+      )}
+
       {editItem !== undefined && (
         <EditItemModal
           item={editItem}

--- a/frontend/src/admin/pages/MenuPage.jsx
+++ b/frontend/src/admin/pages/MenuPage.jsx
@@ -5,6 +5,7 @@ import {
   createCategory, updateCategory, deleteCategory,
   createMenuOption, updateMenuOption, deleteMenuOption,
   uploadMenuImage,
+  fetchSetOptions, updateSetOption,
 } from '../api/adminApi.js'
 
 const OPTION_GROUPS = [
@@ -404,8 +405,109 @@ function OptionGroupSection({ group, options, item, onAdd, onEdit, onDelete, onT
   )
 }
 
+// ─── SetOptionsPanel ── 세트 공통 구성 일괄 편집 ─────────────────────────────
+function SetOptionsPanel() {
+  const [setOpts,    setSetOpts]    = useState(null)   // { SET_SIDE: [], SET_DRINK: [] }
+  const [editing,    setEditing]    = useState({})     // { "SET_SIDE::감자튀김": "500" }
+  const [saving,     setSaving]     = useState({})
+  const [loadErr,    setLoadErr]    = useState('')
+
+  const load = () =>
+    fetchSetOptions()
+      .then(d => { setSetOpts(d); setEditing({}) })
+      .catch(e => setLoadErr(e.message))
+
+  useEffect(() => { load() }, [])
+
+  const key = (grp, name) => `${grp}::${name}`
+
+  const handleSave = async (grp, name, price) => {
+    const k = key(grp, name)
+    setSaving(s => ({ ...s, [k]: true }))
+    try {
+      await updateSetOption({ option_group: grp, name_ko: name, additional_price: Number(price) })
+      setEditing(e => { const n = { ...e }; delete n[k]; return n })
+      load()
+    } catch (e) {
+      alert(e.message)
+    } finally {
+      setSaving(s => { const n = { ...s }; delete n[k]; return n })
+    }
+  }
+
+  if (loadErr) return <div style={{ color: '#c00', padding: 16, fontSize: 13 }}>{loadErr}</div>
+  if (!setOpts) return <div className="loading-text" style={{ fontSize: 12 }}>로딩 중…</div>
+
+  const renderGroup = (grp, label) => (
+    <div key={grp}>
+      <div style={{ fontWeight: 700, fontSize: 13, color: '#744032', marginBottom: 8, padding: '4px 0' }}>{label}</div>
+      <table className="data-table" style={{ tableLayout: 'fixed', width: '100%', marginBottom: 0 }}>
+        <colgroup>
+          <col /><col style={{ width: 130 }} /><col style={{ width: 90 }} />
+        </colgroup>
+        <thead>
+          <tr><th>이름</th><th>추가금 (원)</th><th></th></tr>
+        </thead>
+        <tbody>
+          {(setOpts[grp] ?? []).map(opt => {
+            const k = key(grp, opt.name_ko)
+            const isEdit = k in editing
+            const val = isEdit ? editing[k] : String(opt.additional_price)
+            return (
+              <tr key={opt.name_ko}>
+                <td style={{ fontWeight: 500 }}>{opt.name_ko}</td>
+                <td>
+                  {isEdit ? (
+                    <input
+                      className="form-input"
+                      type="number" min="0" step="100"
+                      value={val}
+                      style={{ padding: '4px 8px', fontSize: 13, height: 32 }}
+                      onChange={e => setEditing(ed => ({ ...ed, [k]: e.target.value }))}
+                      onKeyDown={e => { if (e.key === 'Enter') handleSave(grp, opt.name_ko, val) }}
+                      autoFocus
+                    />
+                  ) : (
+                    <span style={{ color: Number(opt.additional_price) > 0 ? '#F5B800' : '#aaa', fontWeight: 600 }}>
+                      {Number(opt.additional_price) > 0 ? `+${Number(opt.additional_price).toLocaleString('ko-KR')}원` : '–'}
+                    </span>
+                  )}
+                </td>
+                <td>
+                  {isEdit ? (
+                    <div style={{ display: 'flex', gap: 4 }}>
+                      <button className="btn-primary btn-sm" disabled={saving[k]} onClick={() => handleSave(grp, opt.name_ko, val)}>
+                        {saving[k] ? '…' : '저장'}
+                      </button>
+                      <button className="btn-outline btn-sm" onClick={() => setEditing(e => { const n = { ...e }; delete n[k]; return n })}>
+                        취소
+                      </button>
+                    </div>
+                  ) : (
+                    <button className="btn-outline btn-sm" onClick={() => setEditing(e => ({ ...e, [k]: String(opt.additional_price) }))}>
+                      수정
+                    </button>
+                  )}
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+      {renderGroup('SET_SIDE',  '사이드 선택 옵션')}
+      {renderGroup('SET_DRINK', '음료 선택 옵션')}
+    </div>
+  )
+}
+
 // ─── MenuPage ────────────────────────────────────────────────────────────────
 export default function MenuPage() {
+  const [activeTab,     setActiveTab]     = useState('menu')   // 'menu' | 'set'
   const [data,          setData]          = useState(null)
   const [loading,       setLoading]       = useState(true)
   const [error,         setError]         = useState('')
@@ -570,7 +672,38 @@ export default function MenuPage() {
   const selectedItemFull = selectedItem ? allItems.find(i => i.id === selectedItem) ?? null : null
 
   return (
-    <div style={{ display: 'flex', gap: 16, alignItems: 'flex-start' }}>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+
+      {/* ── 탭 ── */}
+      <div style={{ display: 'flex', gap: 0, borderBottom: '2px solid #eee' }}>
+        {[
+          { key: 'menu', label: '메뉴 관리' },
+          { key: 'set',  label: '세트 구성' },
+        ].map(tab => (
+          <button
+            key={tab.key}
+            onClick={() => setActiveTab(tab.key)}
+            style={{
+              background: 'none', border: 'none', cursor: 'pointer',
+              padding: '10px 22px', fontSize: 14, fontWeight: activeTab === tab.key ? 700 : 500,
+              color: activeTab === tab.key ? '#744032' : '#888',
+              borderBottom: activeTab === tab.key ? '2px solid #744032' : '2px solid transparent',
+              marginBottom: -2, transition: 'all 0.15s',
+            }}
+          >{tab.label}</button>
+        ))}
+      </div>
+
+      {/* ── 세트 구성 탭 ── */}
+      {activeTab === 'set' && (
+        <div className="card" style={{ maxWidth: 560 }}>
+          <div style={{ fontWeight: 700, fontSize: 15, marginBottom: 20 }}>세트 구성 일괄 편집</div>
+          <SetOptionsPanel />
+        </div>
+      )}
+
+      {/* ── 메뉴 관리 탭 ── */}
+      {activeTab === 'menu' && <div style={{ display: 'flex', gap: 16, alignItems: 'flex-start' }}>
 
       {/* ── 카테고리 패널 ── */}
       <div className="card" style={{ width: 200, minWidth: 200, padding: '8px 0' }}>
@@ -768,6 +901,8 @@ export default function MenuPage() {
           onSave={handleSaveOption}
         />
       )}
+      </div>}
+
     </div>
   )
 }

--- a/frontend/src/admin/pages/MenuPage.jsx
+++ b/frontend/src/admin/pages/MenuPage.jsx
@@ -9,24 +9,29 @@ import {
 
 const OPTION_GROUPS = [
   { value: 'SET_UPGRADE', label: '단품/세트' },
-  { value: 'EXCLUDE',     label: '제외하기' },
-  { value: 'SET_SIDE',    label: '사이드'   },
-  { value: 'SET_DRINK',   label: '음료수'   },
+  { value: 'EXCLUDE',     label: '제외하기'  },
+  { value: 'SET_SIDE',    label: '사이드'    },
+  { value: 'SET_DRINK',   label: '음료수'    },
 ]
 const GROUP_LABEL = Object.fromEntries(OPTION_GROUPS.map(g => [g.value, g.label]))
 
-// ─── Toggle ────────────────────────────────────────────────────────────────
+// ─── Toggle ─── (div 기반, label→input 이중클릭 없음) ──────────────────────
 function Toggle({ checked, onChange }) {
   return (
-    <label className="toggle" onClick={e => { e.stopPropagation(); onChange(!checked) }}>
-      <input type="checkbox" checked={checked} onChange={() => {}} />
-      <div className="toggle-track" />
+    <div
+      role="switch"
+      aria-checked={checked}
+      className="toggle"
+      onClick={e => { e.stopPropagation(); onChange(!checked) }}
+      style={{ cursor: 'pointer', display: 'inline-flex', alignItems: 'center' }}
+    >
+      <div className="toggle-track" style={{ background: checked ? '#744032' : '#ccc' }} />
       <div className="toggle-thumb" />
-    </label>
+    </div>
   )
 }
 
-// ─── ImageUploader ─────────────────────────────────────────────────────────
+// ─── ImageUploader ──────────────────────────────────────────────────────────
 function ImageUploader({ url, onChange }) {
   const fileRef = useRef(null)
   const [uploading, setUploading] = useState(false)
@@ -87,9 +92,14 @@ function ImageUploader({ url, onChange }) {
   )
 }
 
-// ─── EditCategoryModal ─────────────────────────────────────────────────────
-function EditCategoryModal({ onClose, onSave }) {
-  const [form, setForm] = useState({ name_ko: '', name_en: '', display_order: 0 })
+// ─── EditCategoryModal ── 생성/수정 겸용 ────────────────────────────────────
+function EditCategoryModal({ category, onClose, onSave }) {
+  const isEdit = !!category
+  const [form, setForm] = useState({
+    name_ko:       category?.name_ko       ?? '',
+    name_en:       category?.name_en       ?? '',
+    display_order: category?.display_order ?? 0,
+  })
   const [loading, setLoading] = useState(false)
   const set = (k, v) => setForm(f => ({ ...f, [k]: v }))
 
@@ -98,7 +108,7 @@ function EditCategoryModal({ onClose, onSave }) {
     if (!form.name_en.trim()) { alert('영어 이름을 입력하세요'); return }
     setLoading(true)
     try {
-      await onSave({ ...form, display_order: Number(form.display_order), is_visible: true })
+      await onSave({ ...form, display_order: Number(form.display_order) })
       onClose()
     } catch (e) {
       alert(e.message)
@@ -110,7 +120,7 @@ function EditCategoryModal({ onClose, onSave }) {
   return (
     <div className="modal-overlay">
       <div className="modal-box" style={{ width: 400 }}>
-        <div className="modal-title">카테고리 추가</div>
+        <div className="modal-title">{isEdit ? '카테고리 수정' : '카테고리 추가'}</div>
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginBottom: 12 }}>
           <div className="form-group" style={{ marginBottom: 0 }}>
             <label className="form-label">이름 (한국어) *</label>
@@ -129,7 +139,7 @@ function EditCategoryModal({ onClose, onSave }) {
         <div className="modal-footer">
           <button className="btn-outline" onClick={onClose}>취소</button>
           <button className="btn-primary" onClick={handleSave} disabled={loading}>
-            {loading ? '저장 중…' : '추가'}
+            {loading ? '저장 중…' : isEdit ? '수정' : '추가'}
           </button>
         </div>
       </div>
@@ -137,19 +147,19 @@ function EditCategoryModal({ onClose, onSave }) {
   )
 }
 
-// ─── EditItemModal ─────────────────────────────────────────────────────────
+// ─── EditItemModal ──────────────────────────────────────────────────────────
 function EditItemModal({ item, categoryId, categories, onClose, onSave }) {
   const [form, setForm] = useState({
-    name_ko:      item?.name_ko      ?? '',
-    name_en:      item?.name_en      ?? '',
-    base_price:   item?.base_price   ?? '',
-    description:  item?.description  ?? '',
-    image_url:    item?.image_url    ?? null,
+    name_ko:       item?.name_ko       ?? '',
+    name_en:       item?.name_en       ?? '',
+    base_price:    item?.base_price    ?? '',
+    description:   item?.description   ?? '',
+    image_url:     item?.image_url     ?? null,
     set_image_url: item?.set_image_url ?? null,
-    is_available: item?.is_available ?? true,
-    is_popular:   item?.is_popular   ?? false,
-    is_new:       item?.is_new       ?? false,
-    category_id:  categoryId ?? categories?.[0]?.id ?? '',
+    is_available:  item?.is_available  ?? true,
+    is_popular:    item?.is_popular    ?? false,
+    is_new:        item?.is_new        ?? false,
+    category_id:   item?.category_id ?? categoryId ?? categories?.[0]?.id ?? '',
   })
   const [loading, setLoading] = useState(false)
   const set = (k, v) => setForm(f => ({ ...f, [k]: v }))
@@ -231,13 +241,13 @@ function EditItemModal({ item, categoryId, categories, onClose, onSave }) {
   )
 }
 
-// ─── EditOptionModal ───────────────────────────────────────────────────────
-function EditOptionModal({ option, itemId, onClose, onSave }) {
+// ─── EditOptionModal ─────────────────────────────────────────────────────────
+function EditOptionModal({ option, itemId, defaultGroup, onClose, onSave }) {
   const [form, setForm] = useState({
     name_ko:          option?.name_ko          ?? '',
     name_en:          option?.name_en          ?? '',
     additional_price: option?.additional_price != null ? Number(option.additional_price) : 0,
-    option_group:     option?.option_group     ?? 'EXCLUDE',
+    option_group:     option?.option_group     ?? defaultGroup ?? 'EXCLUDE',
     display_order:    option?.display_order    ?? 0,
     is_available:     option?.is_available     ?? true,
   })
@@ -273,7 +283,7 @@ function EditOptionModal({ option, itemId, onClose, onSave }) {
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginBottom: 12 }}>
           <div className="form-group" style={{ marginBottom: 0 }}>
             <label className="form-label">이름 (한국어) *</label>
-            <input className="form-input" value={form.name_ko} onChange={e => set('name_ko', e.target.value)} />
+            <input className="form-input" value={form.name_ko} onChange={e => set('name_ko', e.target.value)} autoFocus />
           </div>
           <div className="form-group" style={{ marginBottom: 0 }}>
             <label className="form-label">이름 (영어) *</label>
@@ -310,27 +320,110 @@ function EditOptionModal({ option, itemId, onClose, onSave }) {
   )
 }
 
-// ─── MenuPage ──────────────────────────────────────────────────────────────
+// ─── OptionGroupSection ── 그룹별 섹션 ──────────────────────────────────────
+function OptionGroupSection({ group, options, item, onAdd, onEdit, onDelete, onToggle, deletingOpt }) {
+  const groupOptions = options.filter(o => o.option_group === group.value)
+    .sort((a, b) => a.display_order - b.display_order)
+
+  return (
+    <div style={{ borderBottom: '1px solid #f0f0f0' }}>
+      {/* 섹션 헤더 */}
+      <div style={{
+        padding: '10px 20px',
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        background: '#fafafa',
+      }}>
+        <span style={{
+          fontSize: 12, fontWeight: 700, color: '#744032',
+          padding: '2px 10px', background: '#f0ebe8', borderRadius: 999,
+        }}>
+          {group.label}
+        </span>
+        <button
+          className="btn-outline btn-sm"
+          style={{ fontSize: 11, padding: '3px 10px' }}
+          onClick={() => onAdd(group.value)}
+        >
+          + 추가
+        </button>
+      </div>
+
+      {/* 옵션 목록 */}
+      {groupOptions.length === 0 ? (
+        <div style={{ padding: '10px 20px', fontSize: 13, color: '#bbb' }}>
+          {group.label} 항목이 없습니다
+        </div>
+      ) : (
+        <table className="data-table" style={{ margin: 0 }}>
+          <thead>
+            <tr>
+              <th>한국어</th>
+              <th>영어</th>
+              <th style={{ width: 90 }}>추가금액</th>
+              <th style={{ width: 60 }}>판매</th>
+              <th style={{ width: 100 }}></th>
+            </tr>
+          </thead>
+          <tbody>
+            {groupOptions.map(opt => (
+              <tr key={opt.id}>
+                <td style={{ fontWeight: 500 }}>{opt.name_ko}</td>
+                <td style={{ color: '#888', fontSize: 12 }}>{opt.name_en}</td>
+                <td>
+                  {Number(opt.additional_price) > 0
+                    ? <span style={{ color: '#F5B800', fontWeight: 600 }}>+{Number(opt.additional_price).toLocaleString('ko-KR')}원</span>
+                    : <span style={{ color: '#bbb' }}>-</span>
+                  }
+                </td>
+                <td>
+                  <Toggle
+                    checked={opt.is_available}
+                    onChange={() => onToggle(item, opt)}
+                  />
+                </td>
+                <td style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                  <button className="btn-outline btn-sm" onClick={() => onEdit(opt)}>수정</button>
+                  <button
+                    className="btn-sm"
+                    style={{ background: '#ffeaea', color: '#c00', border: '1px solid #ffc0c0', borderRadius: 6, cursor: 'pointer', fontSize: 12, padding: '4px 10px' }}
+                    disabled={deletingOpt === opt.id}
+                    onClick={() => {
+                      if (confirm(`"${opt.name_ko}" 옵션을 삭제하시겠습니까?`))
+                        onDelete(item.id, opt.id)
+                    }}
+                  >
+                    {deletingOpt === opt.id ? '…' : '삭제'}
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}
+
+// ─── MenuPage ────────────────────────────────────────────────────────────────
 export default function MenuPage() {
-  const [data,         setData]         = useState(null)
-  const [loading,      setLoading]      = useState(true)
-  const [error,        setError]        = useState('')
-  const [selectedCat,  setSelectedCat]  = useState(null)
-  const [selectedItem, setSelectedItem] = useState(null)
-  const [editItem,     setEditItem]     = useState(undefined)   // undefined=hidden | null=new | obj=edit
-  const [editOption,   setEditOption]   = useState(undefined)   // undefined=hidden | null=new | obj=edit
-  const [editCat,      setEditCat]      = useState(false)        // false=hidden | true=show
-  const [deletingOpt,  setDeletingOpt]  = useState(null)
-  const [deletingItem, setDeletingItem] = useState(null)
-  const [deletingCat,  setDeletingCat]  = useState(null)
+  const [data,          setData]          = useState(null)
+  const [loading,       setLoading]       = useState(true)
+  const [error,         setError]         = useState('')
+  const [selectedCat,   setSelectedCat]   = useState(null)   // null = 전체
+  const [selectedItem,  setSelectedItem]  = useState(null)
+  const [editItem,      setEditItem]      = useState(undefined)  // undefined=숨김 | null=신규 | obj=수정
+  const [editOption,    setEditOption]    = useState(undefined)  // undefined=숨김 | null=신규 | obj=수정
+  const [editOptionGroup, setEditOptionGroup] = useState(null)   // editOption=null 일 때 기본 그룹
+  // editCat: null=숨김, true=신규 추가, object=수정 대상 카테고리
+  const [editCat,       setEditCat]       = useState(null)
+  const [deletingOpt,   setDeletingOpt]   = useState(null)
+  const [deletingItem,  setDeletingItem]  = useState(null)
+  const [deletingCat,   setDeletingCat]   = useState(null)
 
   const load = () => {
     setLoading(true)
     fetchAdminMenu()
-      .then(raw => {
-        setData(raw)
-        setSelectedCat(c => c ?? raw.categories?.[0]?.id ?? null)
-      })
+      .then(raw => { setData(raw) })
       .catch(e => setError(e.message))
       .finally(() => setLoading(false))
   }
@@ -380,7 +473,11 @@ export default function MenuPage() {
   }
 
   const handleSaveCat = async (payload) => {
-    await createCategory(payload)
+    if (editCat && editCat !== true) {
+      await updateCategory(editCat.id, payload)
+    } else {
+      await createCategory({ ...payload, is_visible: true })
+    }
     load()
   }
 
@@ -404,6 +501,16 @@ export default function MenuPage() {
     catch (e) { alert(e.message) }
   }
 
+  const openAddOption = (group) => {
+    setEditOption(null)
+    setEditOptionGroup(group)
+  }
+
+  const openEditOption = (opt) => {
+    setEditOption(opt)
+    setEditOptionGroup(null)
+  }
+
   if (loading) return <div className="loading-text">메뉴 데이터 로딩 중…</div>
   if (error)   return <div className="loading-text" style={{ color:'#c00' }}>{error}</div>
 
@@ -417,14 +524,14 @@ export default function MenuPage() {
     return data.menu_items[catKey] ?? []
   })()
 
-  const currentCat       = data?.categories?.find(c => c.id === selectedCat)
+  const currentCat      = data?.categories?.find(c => c.id === selectedCat)
   const selectedItemFull = selectedItem ? allItems.find(i => i.id === selectedItem) ?? null : null
 
   return (
     <div style={{ display: 'flex', gap: 16, alignItems: 'flex-start' }}>
 
       {/* ── 카테고리 패널 ── */}
-      <div className="card" style={{ width: 180, minWidth: 180, padding: '8px 0' }}>
+      <div className="card" style={{ width: 200, minWidth: 200, padding: '8px 0' }}>
         <div style={{ padding: '12px 16px 8px', fontWeight: 700, fontSize: 14, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <span>카테고리</span>
           <button
@@ -433,29 +540,46 @@ export default function MenuPage() {
             onClick={() => setEditCat(true)}
           >+ 추가</button>
         </div>
+
+        {/* 전체 */}
+        <div
+          onClick={() => { setSelectedCat(null); setSelectedItem(null) }}
+          style={{
+            padding: '8px 16px', cursor: 'pointer',
+            display: 'flex', alignItems: 'center',
+            background:  !selectedCat ? '#fff5f0' : 'transparent',
+            borderLeft:  !selectedCat ? '3px solid #744032' : '3px solid transparent',
+            fontWeight:  !selectedCat ? 600 : 400,
+            fontSize: 14, color: '#555',
+          }}
+        >
+          전체
+        </div>
+
         {(data?.categories ?? []).map(cat => (
           <div
             key={cat.id}
             onClick={() => { setSelectedCat(cat.id); setSelectedItem(null) }}
             style={{
-              padding: '8px 16px', cursor: 'pointer',
+              padding: '8px 16px 8px 12px', cursor: 'pointer',
               display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-              background:   selectedCat === cat.id ? '#fff5f0' : 'transparent',
-              borderLeft:   selectedCat === cat.id ? '3px solid #744032' : '3px solid transparent',
-              fontWeight:   selectedCat === cat.id ? 600 : 400,
+              background:  selectedCat === cat.id ? '#fff5f0' : 'transparent',
+              borderLeft:  selectedCat === cat.id ? '3px solid #744032' : '3px solid transparent',
+              fontWeight:  selectedCat === cat.id ? 600 : 400,
             }}
           >
-            <span style={{ fontSize: 14, flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{cat.name_ko}</span>
+            <span style={{ fontSize: 13, flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {cat.name_ko}
+            </span>
             <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexShrink: 0 }} onClick={e => e.stopPropagation()}>
-              <span
-                className={`badge ${cat.is_visible ? 'badge-active' : 'badge-inactive'}`}
-                style={{ fontSize: 10, padding: '1px 7px', cursor: 'pointer' }}
-                onClick={() => handleToggleCatVisible(cat)}
-              >
-                {cat.is_visible ? '노출' : '숨김'}
-              </span>
+              <Toggle checked={cat.is_visible} onChange={() => handleToggleCatVisible(cat)} />
               <button
-                style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#bbb', fontSize: 14, lineHeight: 1, padding: '0 2px' }}
+                style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#aaa', fontSize: 13, lineHeight: 1, padding: '1px 2px' }}
+                onClick={() => setEditCat(cat)}
+                title="카테고리 수정"
+              >✎</button>
+              <button
+                style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#bbb', fontSize: 13, lineHeight: 1, padding: '1px 2px' }}
                 disabled={deletingCat === cat.id}
                 onClick={() => handleDeleteCat(cat)}
                 title="삭제"
@@ -471,7 +595,7 @@ export default function MenuPage() {
       <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 16 }}>
         <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
           <div style={{ padding: '16px 20px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', borderBottom: '1px solid #f0f0f0' }}>
-            <span style={{ fontWeight: 600, fontSize: 15 }}>{currentCat?.name_ko ?? '전체'}</span>
+            <span style={{ fontWeight: 600, fontSize: 15 }}>{currentCat?.name_ko ?? '전체 메뉴'}</span>
             <button className="btn-primary btn-sm" onClick={() => setEditItem(null)}>+ 메뉴 추가</button>
           </div>
           <table className="data-table">
@@ -479,132 +603,88 @@ export default function MenuPage() {
               <tr>
                 <th style={{ width: 56 }}></th>
                 <th>이름</th>
+                <th>카테고리</th>
                 <th>가격</th>
-                <th>품절여부</th>
+                <th>품절</th>
                 <th>상태</th>
                 <th style={{ width: 110 }}>수정/삭제</th>
               </tr>
             </thead>
             <tbody>
               {displayItems.length === 0 && (
-                <tr><td colSpan={6} className="loading-text">메뉴가 없습니다</td></tr>
+                <tr><td colSpan={7} className="loading-text">메뉴가 없습니다</td></tr>
               )}
-              {displayItems.map(item => (
-                <tr
-                  key={item.id}
-                  className={selectedItem === item.id ? 'selected' : ''}
-                  style={{ cursor: 'pointer' }}
-                  onClick={() => setSelectedItem(selectedItem === item.id ? null : item.id)}
-                >
-                  <td>
-                    {item.image_url
-                      ? <img src={item.image_url} alt="" style={{ width: 40, height: 40, objectFit: 'cover', borderRadius: 6 }} />
-                      : <div style={{ width: 40, height: 40, background: '#f5f5f5', borderRadius: 6, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 18 }}>🍔</div>
-                    }
-                  </td>
-                  <td style={{ fontWeight: 500 }}>{item.name_ko}</td>
-                  <td>{Number(item.base_price).toLocaleString('ko-KR')}원</td>
-                  <td onClick={e => e.stopPropagation()}>
-                    <Toggle checked={!item.is_available} onChange={() => handleToggleAvailable(item)} />
-                  </td>
-                  <td>
-                    <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
-                      {item.is_popular   && <span className="badge badge-active"    style={{ fontSize: 10, padding: '1px 7px' }}>인기</span>}
-                      {item.is_new       && <span className="badge badge-received"  style={{ fontSize: 10, padding: '1px 7px' }}>신메뉴</span>}
-                      {!item.is_available && <span className="badge badge-cancelled" style={{ fontSize: 10, padding: '1px 7px' }}>품절</span>}
-                    </div>
-                  </td>
-                  <td onClick={e => e.stopPropagation()}>
-                    <div style={{ display: 'flex', gap: 4 }}>
-                      <button className="btn-outline btn-sm" onClick={() => setEditItem(item)}>수정</button>
-                      <button
-                        className="btn-sm"
-                        style={{ background: '#ffeaea', color: '#c00', border: '1px solid #ffc0c0', borderRadius: 6, fontSize: 12, padding: '4px 8px', cursor: 'pointer' }}
-                        disabled={deletingItem === item.id}
-                        onClick={() => {
-                          if (confirm(`"${item.name_ko}"을(를) 삭제하시겠습니까?\n진행 중인 주문이 있으면 품절 처리됩니다.`))
-                            handleDeleteItem(item.id)
-                        }}
-                      >
-                        {deletingItem === item.id ? '…' : '삭제'}
-                      </button>
-                    </div>
-                  </td>
-                </tr>
-              ))}
+              {displayItems.map(item => {
+                const cat = data?.categories?.find(c => c.id === item.category_id)
+                return (
+                  <tr
+                    key={item.id}
+                    className={selectedItem === item.id ? 'selected' : ''}
+                    style={{ cursor: 'pointer' }}
+                    onClick={() => setSelectedItem(selectedItem === item.id ? null : item.id)}
+                  >
+                    <td>
+                      {item.image_url
+                        ? <img src={item.image_url} alt="" style={{ width: 40, height: 40, objectFit: 'cover', borderRadius: 6 }} />
+                        : <div style={{ width: 40, height: 40, background: '#f5f5f5', borderRadius: 6, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 18 }}>🍔</div>
+                      }
+                    </td>
+                    <td style={{ fontWeight: 500 }}>{item.name_ko}</td>
+                    <td style={{ fontSize: 12, color: '#888' }}>{cat?.name_ko ?? '–'}</td>
+                    <td>{Number(item.base_price).toLocaleString('ko-KR')}원</td>
+                    <td onClick={e => e.stopPropagation()}>
+                      <Toggle checked={!item.is_available} onChange={() => handleToggleAvailable(item)} />
+                    </td>
+                    <td>
+                      <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+                        {item.is_popular    && <span className="badge badge-active"    style={{ fontSize: 10, padding: '1px 7px' }}>인기</span>}
+                        {item.is_new        && <span className="badge badge-received"  style={{ fontSize: 10, padding: '1px 7px' }}>신메뉴</span>}
+                        {!item.is_available && <span className="badge badge-cancelled" style={{ fontSize: 10, padding: '1px 7px' }}>품절</span>}
+                      </div>
+                    </td>
+                    <td onClick={e => e.stopPropagation()}>
+                      <div style={{ display: 'flex', gap: 4 }}>
+                        <button className="btn-outline btn-sm" onClick={() => setEditItem(item)}>수정</button>
+                        <button
+                          className="btn-sm"
+                          style={{ background: '#ffeaea', color: '#c00', border: '1px solid #ffc0c0', borderRadius: 6, fontSize: 12, padding: '4px 8px', cursor: 'pointer' }}
+                          disabled={deletingItem === item.id}
+                          onClick={() => {
+                            if (confirm(`"${item.name_ko}"을(를) 삭제하시겠습니까?\n진행 중인 주문이 있으면 품절 처리됩니다.`))
+                              handleDeleteItem(item.id)
+                          }}
+                        >
+                          {deletingItem === item.id ? '…' : '삭제'}
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                )
+              })}
             </tbody>
           </table>
         </div>
 
-        {/* ── 옵션 패널 ── */}
+        {/* ── 옵션 패널 (그룹별 섹션) ── */}
         {selectedItemFull && (
           <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
             <div style={{ padding: '14px 20px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', borderBottom: '1px solid #f0f0f0' }}>
-              <span style={{ fontWeight: 600, fontSize: 14 }}>{selectedItemFull.name_ko} 옵션</span>
-              <button className="btn-primary btn-sm" onClick={() => setEditOption(null)}>+ 옵션 추가</button>
+              <span style={{ fontWeight: 600, fontSize: 14 }}>{selectedItemFull.name_ko} — 옵션 구성</span>
             </div>
 
-            {(!selectedItemFull.options || selectedItemFull.options.length === 0) ? (
-              <div className="loading-text" style={{ padding: '20px 0' }}>옵션이 없습니다</div>
-            ) : (
-              <table className="data-table">
-                <thead>
-                  <tr>
-                    <th style={{ width: 90 }}>그룹</th>
-                    <th>한국어</th>
-                    <th>영어</th>
-                    <th style={{ width: 90 }}>추가금액</th>
-                    <th style={{ width: 70 }}>판매</th>
-                    <th style={{ width: 100 }}></th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {[...selectedItemFull.options]
-                    .sort((a, b) => {
-                      const gi = g => OPTION_GROUPS.findIndex(x => x.value === g)
-                      return gi(a.option_group) - gi(b.option_group) || a.display_order - b.display_order
-                    })
-                    .map(opt => (
-                      <tr key={opt.id}>
-                        <td>
-                          <span style={{ fontSize: 11, padding: '2px 8px', borderRadius: 999, background: '#f0ebe8', color: '#744032', fontWeight: 600 }}>
-                            {GROUP_LABEL[opt.option_group] ?? opt.option_group}
-                          </span>
-                        </td>
-                        <td style={{ fontWeight: 500 }}>{opt.name_ko}</td>
-                        <td style={{ color: '#888', fontSize: 12 }}>{opt.name_en}</td>
-                        <td>
-                          {Number(opt.additional_price) > 0
-                            ? <span style={{ color: '#F5B800', fontWeight: 600 }}>+{Number(opt.additional_price).toLocaleString('ko-KR')}원</span>
-                            : <span style={{ color: '#bbb' }}>-</span>
-                          }
-                        </td>
-                        <td>
-                          <Toggle
-                            checked={opt.is_available}
-                            onChange={() => handleToggleOptionAvailable(selectedItemFull, opt)}
-                          />
-                        </td>
-                        <td style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
-                          <button className="btn-outline btn-sm" onClick={() => setEditOption(opt)}>수정</button>
-                          <button
-                            className="btn-sm"
-                            style={{ background: '#ffeaea', color: '#c00', border: '1px solid #ffc0c0', borderRadius: 6, cursor: 'pointer', fontSize: 12, padding: '4px 10px' }}
-                            disabled={deletingOpt === opt.id}
-                            onClick={() => {
-                              if (confirm(`"${opt.name_ko}" 옵션을 삭제하시겠습니까?`))
-                                handleDeleteOption(selectedItemFull.id, opt.id)
-                            }}
-                          >
-                            {deletingOpt === opt.id ? '…' : '삭제'}
-                          </button>
-                        </td>
-                      </tr>
-                    ))
-                  }
-                </tbody>
-              </table>
-            )}
+            {OPTION_GROUPS.map(group => (
+              <OptionGroupSection
+                key={group.value}
+                group={group}
+                options={selectedItemFull.options ?? []}
+                item={selectedItemFull}
+                onAdd={openAddOption}
+                onEdit={openEditOption}
+                onDelete={handleDeleteOption}
+                onToggle={handleToggleOptionAvailable}
+                deletingOpt={deletingOpt}
+              />
+            ))}
           </div>
         )}
       </div>
@@ -612,7 +692,8 @@ export default function MenuPage() {
       {/* ── 모달 ── */}
       {editCat && (
         <EditCategoryModal
-          onClose={() => setEditCat(false)}
+          category={editCat === true ? null : editCat}
+          onClose={() => setEditCat(null)}
           onSave={handleSaveCat}
         />
       )}
@@ -631,7 +712,8 @@ export default function MenuPage() {
         <EditOptionModal
           option={editOption}
           itemId={selectedItemFull.id}
-          onClose={() => setEditOption(undefined)}
+          defaultGroup={editOptionGroup}
+          onClose={() => { setEditOption(undefined); setEditOptionGroup(null) }}
           onSave={handleSaveOption}
         />
       )}

--- a/frontend/src/admin/pages/MenuPage.jsx
+++ b/frontend/src/admin/pages/MenuPage.jsx
@@ -1,0 +1,517 @@
+import { useRef, useState, useEffect } from 'react'
+import {
+  fetchAdminMenu,
+  updateMenuItem, createMenuItem,
+  updateCategory,
+  createMenuOption, updateMenuOption, deleteMenuOption,
+  uploadMenuImage,
+} from '../api/adminApi.js'
+
+const OPTION_GROUPS = [
+  { value: 'SET_UPGRADE', label: '단품/세트' },
+  { value: 'EXCLUDE',     label: '제외하기' },
+  { value: 'SET_SIDE',    label: '사이드'   },
+  { value: 'SET_DRINK',   label: '음료수'   },
+]
+const GROUP_LABEL = Object.fromEntries(OPTION_GROUPS.map(g => [g.value, g.label]))
+
+// ─── Toggle ────────────────────────────────────────────────────────────────
+function Toggle({ checked, onChange }) {
+  return (
+    <label className="toggle" onClick={e => { e.stopPropagation(); onChange(!checked) }}>
+      <input type="checkbox" checked={checked} onChange={() => {}} />
+      <div className="toggle-track" />
+      <div className="toggle-thumb" />
+    </label>
+  )
+}
+
+// ─── ImageUploader ─────────────────────────────────────────────────────────
+function ImageUploader({ url, onChange }) {
+  const fileRef = useRef(null)
+  const [uploading, setUploading] = useState(false)
+  const [error, setError] = useState('')
+
+  const handleFile = async (e) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setUploading(true)
+    setError('')
+    try {
+      const res = await uploadMenuImage(file)
+      onChange(res.url)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setUploading(false)
+      e.target.value = ''
+    }
+  }
+
+  return (
+    <div style={{ marginBottom: 16 }}>
+      <div className="form-label">이미지</div>
+      <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start' }}>
+        <div style={{
+          width: 80, height: 80, borderRadius: 8, border: '1px solid #e8e8e8',
+          background: '#f5f5f5', overflow: 'hidden', flexShrink: 0,
+          display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 24,
+        }}>
+          {url
+            ? <img src={url} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+            : '🍔'
+          }
+        </div>
+        <div style={{ flex: 1 }}>
+          <input
+            className="form-input"
+            placeholder="이미지 URL 직접 입력"
+            value={url ?? ''}
+            onChange={e => onChange(e.target.value || null)}
+            style={{ marginBottom: 8 }}
+          />
+          <button
+            type="button"
+            className="btn-outline btn-sm"
+            onClick={() => fileRef.current?.click()}
+            disabled={uploading}
+            style={{ fontSize: 12 }}
+          >
+            {uploading ? '업로드 중…' : '파일 업로드'}
+          </button>
+          <input ref={fileRef} type="file" accept="image/*" style={{ display: 'none' }} onChange={handleFile} />
+          {error && <div style={{ color: '#c00', fontSize: 12, marginTop: 4 }}>{error}</div>}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ─── EditItemModal ─────────────────────────────────────────────────────────
+function EditItemModal({ item, categoryId, categories, onClose, onSave }) {
+  const [form, setForm] = useState({
+    name_ko:      item?.name_ko      ?? '',
+    name_en:      item?.name_en      ?? '',
+    base_price:   item?.base_price   ?? '',
+    description:  item?.description  ?? '',
+    image_url:    item?.image_url    ?? null,
+    set_image_url: item?.set_image_url ?? null,
+    is_available: item?.is_available ?? true,
+    is_popular:   item?.is_popular   ?? false,
+    is_new:       item?.is_new       ?? false,
+    category_id:  categoryId ?? categories?.[0]?.id ?? '',
+  })
+  const [loading, setLoading] = useState(false)
+  const set = (k, v) => setForm(f => ({ ...f, [k]: v }))
+
+  const handleSave = async () => {
+    if (!form.name_ko.trim()) { alert('한국어 이름을 입력하세요'); return }
+    if (!form.name_en.trim()) { alert('영어 이름을 입력하세요'); return }
+    if (!form.base_price)     { alert('가격을 입력하세요'); return }
+    setLoading(true)
+    try {
+      await onSave(item?.id, { ...form, base_price: Number(form.base_price) })
+      onClose()
+    } catch (e) {
+      alert(e.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-box" style={{ width: 520, maxHeight: '90vh', overflowY: 'auto' }}>
+        <div className="modal-title">{item ? '메뉴 수정' : '메뉴 추가'}</div>
+
+        <div className="form-group">
+          <label className="form-label">카테고리</label>
+          <select className="form-input" value={form.category_id} onChange={e => set('category_id', e.target.value)}>
+            {(categories ?? []).map(c => <option key={c.id} value={c.id}>{c.name_ko}</option>)}
+          </select>
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginBottom: 12 }}>
+          <div className="form-group" style={{ marginBottom: 0 }}>
+            <label className="form-label">이름 (한국어) *</label>
+            <input className="form-input" value={form.name_ko} onChange={e => set('name_ko', e.target.value)} />
+          </div>
+          <div className="form-group" style={{ marginBottom: 0 }}>
+            <label className="form-label">이름 (영어) *</label>
+            <input className="form-input" value={form.name_en} onChange={e => set('name_en', e.target.value)} />
+          </div>
+        </div>
+
+        <div className="form-group">
+          <label className="form-label">기본 가격 (원) *</label>
+          <input className="form-input" type="number" min="0" value={form.base_price}
+            onChange={e => set('base_price', e.target.value)} />
+        </div>
+
+        <div className="form-group">
+          <label className="form-label">설명</label>
+          <input className="form-input" value={form.description} onChange={e => set('description', e.target.value)} />
+        </div>
+
+        <ImageUploader url={form.image_url} onChange={v => set('image_url', v)} />
+
+        <div className="form-group">
+          <label className="form-label">세트 이미지 URL (없으면 기본 이미지 사용)</label>
+          <input className="form-input" placeholder="/images/sets/..." value={form.set_image_url ?? ''}
+            onChange={e => set('set_image_url', e.target.value || null)} />
+        </div>
+
+        <div style={{ display: 'flex', gap: 20, flexWrap: 'wrap', marginBottom: 20 }}>
+          {[['is_available','판매중'], ['is_popular','인기'], ['is_new','신메뉴']].map(([key, label]) => (
+            <label key={key} style={{ display:'flex', alignItems:'center', gap:6, cursor:'pointer', fontSize:13 }}>
+              <input type="checkbox" checked={form[key]} onChange={e => set(key, e.target.checked)} />
+              {label}
+            </label>
+          ))}
+        </div>
+
+        <div className="modal-footer">
+          <button className="btn-outline" onClick={onClose}>취소</button>
+          <button className="btn-primary" onClick={handleSave} disabled={loading}>
+            {loading ? '저장 중…' : '저장'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ─── EditOptionModal ───────────────────────────────────────────────────────
+function EditOptionModal({ option, itemId, onClose, onSave }) {
+  const [form, setForm] = useState({
+    name_ko:          option?.name_ko          ?? '',
+    name_en:          option?.name_en          ?? '',
+    additional_price: option?.additional_price != null ? Number(option.additional_price) : 0,
+    option_group:     option?.option_group     ?? 'EXCLUDE',
+    display_order:    option?.display_order    ?? 0,
+    is_available:     option?.is_available     ?? true,
+  })
+  const [loading, setLoading] = useState(false)
+  const set = (k, v) => setForm(f => ({ ...f, [k]: v }))
+
+  const handleSave = async () => {
+    if (!form.name_ko.trim()) { alert('한국어 이름을 입력하세요'); return }
+    if (!form.name_en.trim()) { alert('영어 이름을 입력하세요'); return }
+    setLoading(true)
+    try {
+      await onSave(itemId, option?.id, { ...form, additional_price: Number(form.additional_price) })
+      onClose()
+    } catch (e) {
+      alert(e.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-box" style={{ width: 440 }}>
+        <div className="modal-title">{option ? '옵션 수정' : '옵션 추가'}</div>
+
+        <div className="form-group">
+          <label className="form-label">옵션 그룹</label>
+          <select className="form-input" value={form.option_group} onChange={e => set('option_group', e.target.value)}>
+            {OPTION_GROUPS.map(g => <option key={g.value} value={g.value}>{g.label}</option>)}
+          </select>
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginBottom: 12 }}>
+          <div className="form-group" style={{ marginBottom: 0 }}>
+            <label className="form-label">이름 (한국어) *</label>
+            <input className="form-input" value={form.name_ko} onChange={e => set('name_ko', e.target.value)} />
+          </div>
+          <div className="form-group" style={{ marginBottom: 0 }}>
+            <label className="form-label">이름 (영어) *</label>
+            <input className="form-input" value={form.name_en} onChange={e => set('name_en', e.target.value)} />
+          </div>
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginBottom: 12 }}>
+          <div className="form-group" style={{ marginBottom: 0 }}>
+            <label className="form-label">추가 가격 (원)</label>
+            <input className="form-input" type="number" min="0" value={form.additional_price}
+              onChange={e => set('additional_price', e.target.value)} />
+          </div>
+          <div className="form-group" style={{ marginBottom: 0 }}>
+            <label className="form-label">표시 순서</label>
+            <input className="form-input" type="number" min="0" value={form.display_order}
+              onChange={e => set('display_order', Number(e.target.value))} />
+          </div>
+        </div>
+
+        <label style={{ display:'flex', alignItems:'center', gap:8, cursor:'pointer', fontSize:13, marginBottom:20 }}>
+          <input type="checkbox" checked={form.is_available} onChange={e => set('is_available', e.target.checked)} />
+          판매 가능
+        </label>
+
+        <div className="modal-footer">
+          <button className="btn-outline" onClick={onClose}>취소</button>
+          <button className="btn-primary" onClick={handleSave} disabled={loading}>
+            {loading ? '저장 중…' : '저장'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ─── MenuPage ──────────────────────────────────────────────────────────────
+export default function MenuPage() {
+  const [data,         setData]         = useState(null)
+  const [loading,      setLoading]      = useState(true)
+  const [error,        setError]        = useState('')
+  const [selectedCat,  setSelectedCat]  = useState(null)
+  const [selectedItem, setSelectedItem] = useState(null)
+  const [editItem,     setEditItem]     = useState(undefined)   // undefined=hidden | null=new | obj=edit
+  const [editOption,   setEditOption]   = useState(undefined)   // undefined=hidden | null=new | obj=edit
+  const [deletingOpt,  setDeletingOpt]  = useState(null)
+
+  const load = () => {
+    setLoading(true)
+    fetchAdminMenu()
+      .then(raw => {
+        setData(raw)
+        setSelectedCat(c => c ?? raw.categories?.[0]?.id ?? null)
+      })
+      .catch(e => setError(e.message))
+      .finally(() => setLoading(false))
+  }
+
+  useEffect(() => { load() }, [])
+
+  const handleToggleAvailable = async (item) => {
+    try { await updateMenuItem(item.id, { is_available: !item.is_available }); load() }
+    catch (e) { alert(e.message) }
+  }
+
+  const handleToggleCatVisible = async (cat) => {
+    try { await updateCategory(cat.id, { is_visible: !cat.is_visible }); load() }
+    catch (e) { alert(e.message) }
+  }
+
+  const handleSaveItem = async (itemId, payload) => {
+    if (itemId) await updateMenuItem(itemId, payload)
+    else        await createMenuItem(payload)
+    load()
+  }
+
+  const handleSaveOption = async (itemId, optionId, payload) => {
+    if (optionId) await updateMenuOption(itemId, optionId, payload)
+    else          await createMenuOption(itemId, payload)
+    load()
+  }
+
+  const handleDeleteOption = async (itemId, optionId) => {
+    setDeletingOpt(optionId)
+    try { await deleteMenuOption(itemId, optionId); load() }
+    catch (e) { alert(e.message) }
+    finally { setDeletingOpt(null) }
+  }
+
+  const handleToggleOptionAvailable = async (item, opt) => {
+    try { await updateMenuOption(item.id, opt.id, { is_available: !opt.is_available }); load() }
+    catch (e) { alert(e.message) }
+  }
+
+  if (loading) return <div className="loading-text">메뉴 데이터 로딩 중…</div>
+  if (error)   return <div className="loading-text" style={{ color:'#c00' }}>{error}</div>
+
+  const allItems = Object.values(data?.menu_items ?? {}).flat()
+
+  const displayItems = (() => {
+    if (!selectedCat) return allItems
+    const cat = data.categories.find(c => c.id === selectedCat)
+    if (!cat) return allItems
+    const catKey = cat.name_en?.toLowerCase() ?? ''
+    return data.menu_items[catKey] ?? []
+  })()
+
+  const currentCat       = data?.categories?.find(c => c.id === selectedCat)
+  const selectedItemFull = selectedItem ? allItems.find(i => i.id === selectedItem) ?? null : null
+
+  return (
+    <div style={{ display: 'flex', gap: 16, alignItems: 'flex-start' }}>
+
+      {/* ── 카테고리 패널 ── */}
+      <div className="card" style={{ width: 180, minWidth: 180, padding: '8px 0' }}>
+        <div style={{ padding: '12px 16px 8px', fontWeight: 700, fontSize: 14 }}>카테고리</div>
+        {(data?.categories ?? []).map(cat => (
+          <div
+            key={cat.id}
+            onClick={() => { setSelectedCat(cat.id); setSelectedItem(null) }}
+            style={{
+              padding: '10px 16px', cursor: 'pointer',
+              display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+              background:   selectedCat === cat.id ? '#fff5f0' : 'transparent',
+              borderLeft:   selectedCat === cat.id ? '3px solid #744032' : '3px solid transparent',
+              fontWeight:   selectedCat === cat.id ? 600 : 400,
+            }}
+          >
+            <span style={{ fontSize: 14 }}>{cat.name_ko}</span>
+            <span
+              className={`badge ${cat.is_visible ? 'badge-active' : 'badge-inactive'}`}
+              style={{ fontSize: 10, padding: '1px 7px', cursor: 'pointer' }}
+              onClick={e => { e.stopPropagation(); handleToggleCatVisible(cat) }}
+            >
+              {cat.is_visible ? '노출' : '숨김'}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/* ── 메뉴 아이템 패널 ── */}
+      <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
+          <div style={{ padding: '16px 20px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', borderBottom: '1px solid #f0f0f0' }}>
+            <span style={{ fontWeight: 600, fontSize: 15 }}>{currentCat?.name_ko ?? '전체'}</span>
+            <button className="btn-primary btn-sm" onClick={() => setEditItem(null)}>+ 메뉴 추가</button>
+          </div>
+          <table className="data-table">
+            <thead>
+              <tr>
+                <th style={{ width: 56 }}></th>
+                <th>이름</th>
+                <th>가격</th>
+                <th>품절여부</th>
+                <th>상태</th>
+                <th style={{ width: 60 }}>수정</th>
+              </tr>
+            </thead>
+            <tbody>
+              {displayItems.length === 0 && (
+                <tr><td colSpan={6} className="loading-text">메뉴가 없습니다</td></tr>
+              )}
+              {displayItems.map(item => (
+                <tr
+                  key={item.id}
+                  className={selectedItem === item.id ? 'selected' : ''}
+                  style={{ cursor: 'pointer' }}
+                  onClick={() => setSelectedItem(selectedItem === item.id ? null : item.id)}
+                >
+                  <td>
+                    {item.image_url
+                      ? <img src={item.image_url} alt="" style={{ width: 40, height: 40, objectFit: 'cover', borderRadius: 6 }} />
+                      : <div style={{ width: 40, height: 40, background: '#f5f5f5', borderRadius: 6, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 18 }}>🍔</div>
+                    }
+                  </td>
+                  <td style={{ fontWeight: 500 }}>{item.name_ko}</td>
+                  <td>{Number(item.base_price).toLocaleString('ko-KR')}원</td>
+                  <td onClick={e => e.stopPropagation()}>
+                    <Toggle checked={!item.is_available} onChange={() => handleToggleAvailable(item)} />
+                  </td>
+                  <td>
+                    <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+                      {item.is_popular   && <span className="badge badge-active"    style={{ fontSize: 10, padding: '1px 7px' }}>인기</span>}
+                      {item.is_new       && <span className="badge badge-received"  style={{ fontSize: 10, padding: '1px 7px' }}>신메뉴</span>}
+                      {!item.is_available && <span className="badge badge-cancelled" style={{ fontSize: 10, padding: '1px 7px' }}>품절</span>}
+                    </div>
+                  </td>
+                  <td onClick={e => e.stopPropagation()}>
+                    <button className="btn-outline btn-sm" onClick={() => setEditItem(item)}>수정</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* ── 옵션 패널 ── */}
+        {selectedItemFull && (
+          <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
+            <div style={{ padding: '14px 20px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', borderBottom: '1px solid #f0f0f0' }}>
+              <span style={{ fontWeight: 600, fontSize: 14 }}>{selectedItemFull.name_ko} 옵션</span>
+              <button className="btn-primary btn-sm" onClick={() => setEditOption(null)}>+ 옵션 추가</button>
+            </div>
+
+            {(!selectedItemFull.options || selectedItemFull.options.length === 0) ? (
+              <div className="loading-text" style={{ padding: '20px 0' }}>옵션이 없습니다</div>
+            ) : (
+              <table className="data-table">
+                <thead>
+                  <tr>
+                    <th style={{ width: 90 }}>그룹</th>
+                    <th>한국어</th>
+                    <th>영어</th>
+                    <th style={{ width: 90 }}>추가금액</th>
+                    <th style={{ width: 70 }}>판매</th>
+                    <th style={{ width: 100 }}></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {[...selectedItemFull.options]
+                    .sort((a, b) => {
+                      const gi = g => OPTION_GROUPS.findIndex(x => x.value === g)
+                      return gi(a.option_group) - gi(b.option_group) || a.display_order - b.display_order
+                    })
+                    .map(opt => (
+                      <tr key={opt.id}>
+                        <td>
+                          <span style={{ fontSize: 11, padding: '2px 8px', borderRadius: 999, background: '#f0ebe8', color: '#744032', fontWeight: 600 }}>
+                            {GROUP_LABEL[opt.option_group] ?? opt.option_group}
+                          </span>
+                        </td>
+                        <td style={{ fontWeight: 500 }}>{opt.name_ko}</td>
+                        <td style={{ color: '#888', fontSize: 12 }}>{opt.name_en}</td>
+                        <td>
+                          {Number(opt.additional_price) > 0
+                            ? <span style={{ color: '#F5B800', fontWeight: 600 }}>+{Number(opt.additional_price).toLocaleString('ko-KR')}원</span>
+                            : <span style={{ color: '#bbb' }}>-</span>
+                          }
+                        </td>
+                        <td>
+                          <Toggle
+                            checked={opt.is_available}
+                            onChange={() => handleToggleOptionAvailable(selectedItemFull, opt)}
+                          />
+                        </td>
+                        <td style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                          <button className="btn-outline btn-sm" onClick={() => setEditOption(opt)}>수정</button>
+                          <button
+                            className="btn-sm"
+                            style={{ background: '#ffeaea', color: '#c00', border: '1px solid #ffc0c0', borderRadius: 6, cursor: 'pointer', fontSize: 12, padding: '4px 10px' }}
+                            disabled={deletingOpt === opt.id}
+                            onClick={() => {
+                              if (confirm(`"${opt.name_ko}" 옵션을 삭제하시겠습니까?`))
+                                handleDeleteOption(selectedItemFull.id, opt.id)
+                            }}
+                          >
+                            {deletingOpt === opt.id ? '…' : '삭제'}
+                          </button>
+                        </td>
+                      </tr>
+                    ))
+                  }
+                </tbody>
+              </table>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* ── 모달 ── */}
+      {editItem !== undefined && (
+        <EditItemModal
+          item={editItem}
+          categoryId={selectedCat}
+          categories={data?.categories ?? []}
+          onClose={() => setEditItem(undefined)}
+          onSave={handleSaveItem}
+        />
+      )}
+
+      {editOption !== undefined && selectedItemFull && (
+        <EditOptionModal
+          option={editOption}
+          itemId={selectedItemFull.id}
+          onClose={() => setEditOption(undefined)}
+          onSave={handleSaveOption}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/admin/pages/MenuPage.jsx
+++ b/frontend/src/admin/pages/MenuPage.jsx
@@ -413,48 +413,89 @@ export default function MenuPage() {
   const [selectedItem,  setSelectedItem]  = useState(null)
   const [editItem,      setEditItem]      = useState(undefined)  // undefined=숨김 | null=신규 | obj=수정
   const [editOption,    setEditOption]    = useState(undefined)  // undefined=숨김 | null=신규 | obj=수정
-  const [editOptionGroup, setEditOptionGroup] = useState(null)   // editOption=null 일 때 기본 그룹
-  // editCat: null=숨김, true=신규 추가, object=수정 대상 카테고리
-  const [editCat,       setEditCat]       = useState(null)
+  const [editOptionGroup, setEditOptionGroup] = useState(null)
+  const [editCat,       setEditCat]       = useState(null)    // null=숨김 | true=신규 | object=수정
   const [deletingOpt,   setDeletingOpt]   = useState(null)
   const [deletingItem,  setDeletingItem]  = useState(null)
   const [deletingCat,   setDeletingCat]   = useState(null)
 
-  const load = () => {
-    setLoading(true)
-    fetchAdminMenu()
-      .then(raw => { setData(raw) })
-      .catch(e => setError(e.message))
-      .finally(() => setLoading(false))
+  // silent=true: loading 스피너 없이 데이터만 갱신 (스크롤·깜박임 방지)
+  const load = async (silent = false) => {
+    if (!silent) setLoading(true)
+    try {
+      const raw = await fetchAdminMenu()
+      setData(raw)
+    } catch(e) {
+      setError(e.message)
+    } finally {
+      if (!silent) setLoading(false)
+    }
   }
 
   useEffect(() => { load() }, [])
 
+  // ── 낙관적 업데이트 helpers ────────────────────────────────────────────────
+  const patchItem = (itemId, patch) => {
+    setData(prev => {
+      if (!prev) return prev
+      const items = {}
+      for (const key in prev.menu_items) {
+        items[key] = prev.menu_items[key].map(i => i.id === itemId ? { ...i, ...patch } : i)
+      }
+      return { ...prev, menu_items: items }
+    })
+  }
+
+  const patchOption = (itemId, optId, patch) => {
+    setData(prev => {
+      if (!prev) return prev
+      const items = {}
+      for (const key in prev.menu_items) {
+        items[key] = prev.menu_items[key].map(i =>
+          i.id === itemId
+            ? { ...i, options: (i.options ?? []).map(o => o.id === optId ? { ...o, ...patch } : o) }
+            : i
+        )
+      }
+      return { ...prev, menu_items: items }
+    })
+  }
+
+  const patchCat = (catId, patch) => {
+    setData(prev => {
+      if (!prev) return prev
+      return { ...prev, categories: prev.categories.map(c => c.id === catId ? { ...c, ...patch } : c) }
+    })
+  }
+
+  // ── 핸들러 ────────────────────────────────────────────────────────────────
   const handleToggleAvailable = async (item) => {
-    try { await updateMenuItem(item.id, { is_available: !item.is_available }); load() }
-    catch (e) { alert(e.message) }
+    patchItem(item.id, { is_available: !item.is_available })
+    try { await updateMenuItem(item.id, { is_available: !item.is_available }) }
+    catch (e) { alert(e.message); patchItem(item.id, { is_available: item.is_available }) }
   }
 
   const handleToggleCatVisible = async (cat) => {
-    try { await updateCategory(cat.id, { is_visible: !cat.is_visible }); load() }
-    catch (e) { alert(e.message) }
+    patchCat(cat.id, { is_visible: !cat.is_visible })
+    try { await updateCategory(cat.id, { is_visible: !cat.is_visible }) }
+    catch (e) { alert(e.message); patchCat(cat.id, { is_visible: cat.is_visible }) }
   }
 
   const handleSaveItem = async (itemId, payload) => {
     if (itemId) await updateMenuItem(itemId, payload)
     else        await createMenuItem(payload)
-    load()
+    load(true)
   }
 
   const handleSaveOption = async (itemId, optionId, payload) => {
     if (optionId) await updateMenuOption(itemId, optionId, payload)
     else          await createMenuOption(itemId, payload)
-    load()
+    load(true)
   }
 
   const handleDeleteOption = async (itemId, optionId) => {
     setDeletingOpt(optionId)
-    try { await deleteMenuOption(itemId, optionId); load() }
+    try { await deleteMenuOption(itemId, optionId); load(true) }
     catch (e) { alert(e.message) }
     finally { setDeletingOpt(null) }
   }
@@ -468,7 +509,7 @@ export default function MenuPage() {
       alert(e.message)
     } finally {
       setDeletingItem(null)
-      load()
+      load(true)
     }
   }
 
@@ -478,7 +519,7 @@ export default function MenuPage() {
     } else {
       await createCategory({ ...payload, is_visible: true })
     }
-    load()
+    load(true)
   }
 
   const handleDeleteCat = async (cat) => {
@@ -487,18 +528,19 @@ export default function MenuPage() {
     try {
       await deleteCategory(cat.id)
       if (selectedCat === cat.id) setSelectedCat(null)
-      load()
+      load(true)
     } catch (e) {
       alert(e.message)
-      load()
+      load(true)
     } finally {
       setDeletingCat(null)
     }
   }
 
   const handleToggleOptionAvailable = async (item, opt) => {
-    try { await updateMenuOption(item.id, opt.id, { is_available: !opt.is_available }); load() }
-    catch (e) { alert(e.message) }
+    patchOption(item.id, opt.id, { is_available: !opt.is_available })
+    try { await updateMenuOption(item.id, opt.id, { is_available: !opt.is_available }) }
+    catch (e) { alert(e.message); patchOption(item.id, opt.id, { is_available: opt.is_available }) }
   }
 
   const openAddOption = (group) => {
@@ -598,16 +640,25 @@ export default function MenuPage() {
             <span style={{ fontWeight: 600, fontSize: 15 }}>{currentCat?.name_ko ?? '전체 메뉴'}</span>
             <button className="btn-primary btn-sm" onClick={() => setEditItem(null)}>+ 메뉴 추가</button>
           </div>
-          <table className="data-table">
+          <table className="data-table" style={{ tableLayout: 'fixed', width: '100%' }}>
+            <colgroup>
+              <col style={{ width: 56 }} />
+              <col />
+              <col style={{ width: 110 }} />
+              <col style={{ width: 100 }} />
+              <col style={{ width: 64 }} />
+              <col style={{ width: 130 }} />
+              <col style={{ width: 110 }} />
+            </colgroup>
             <thead>
               <tr>
-                <th style={{ width: 56 }}></th>
+                <th></th>
                 <th>이름</th>
                 <th>카테고리</th>
                 <th>가격</th>
                 <th>품절</th>
                 <th>상태</th>
-                <th style={{ width: 110 }}>수정/삭제</th>
+                <th>수정/삭제</th>
               </tr>
             </thead>
             <tbody>
@@ -636,10 +687,10 @@ export default function MenuPage() {
                       <Toggle checked={!item.is_available} onChange={() => handleToggleAvailable(item)} />
                     </td>
                     <td>
-                      <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
-                        {item.is_popular    && <span className="badge badge-active"    style={{ fontSize: 10, padding: '1px 7px' }}>인기</span>}
-                        {item.is_new        && <span className="badge badge-received"  style={{ fontSize: 10, padding: '1px 7px' }}>신메뉴</span>}
-                        {!item.is_available && <span className="badge badge-cancelled" style={{ fontSize: 10, padding: '1px 7px' }}>품절</span>}
+                      <div style={{ display: 'flex', gap: 3, flexWrap: 'nowrap', overflow: 'hidden' }}>
+                        {item.is_popular    && <span className="badge badge-active"    style={{ fontSize: 10, padding: '1px 6px', flexShrink: 0 }}>인기</span>}
+                        {item.is_new        && <span className="badge badge-received"  style={{ fontSize: 10, padding: '1px 6px', flexShrink: 0 }}>신메뉴</span>}
+                        {!item.is_available && <span className="badge badge-cancelled" style={{ fontSize: 10, padding: '1px 6px', flexShrink: 0 }}>품절</span>}
                       </div>
                     </td>
                     <td onClick={e => e.stopPropagation()}>

--- a/frontend/src/admin/pages/OrdersPage.jsx
+++ b/frontend/src/admin/pages/OrdersPage.jsx
@@ -35,6 +35,29 @@ function fmtFull(dt) {
   return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')} ${d.getHours().toString().padStart(2,'0')}:${d.getMinutes().toString().padStart(2,'0')}`
 }
 
+const ELAPSED_ACTIVE = new Set(['RECEIVED', 'COOKING'])
+
+function elapsedColor(minutes) {
+  if (minutes <= 7)  return { bg: '#e8f5e9', color: '#2e7d32' }  // 연두
+  if (minutes <= 15) return { bg: '#fff8e1', color: '#f57f17' }  // 노랑
+  if (minutes <= 25) return { bg: '#fff3e0', color: '#e65100' }  // 주황
+  return               { bg: '#fde8e8', color: '#c0392b' }       // 빨강
+}
+
+function ElapsedBadge({ createdAt, now }) {
+  const minutes = Math.floor((now - new Date(createdAt)) / 60000)
+  const { bg, color } = elapsedColor(minutes)
+  return (
+    <span style={{
+      display: 'inline-block', padding: '2px 8px', borderRadius: 999,
+      fontSize: 12, fontWeight: 700, background: bg, color,
+      whiteSpace: 'nowrap',
+    }}>
+      {minutes}분
+    </span>
+  )
+}
+
 function OrderDetail({ order, onClose, onStatusChange }) {
   if (!order) return null
   const next = nextStatus(order.status)
@@ -126,7 +149,9 @@ export default function OrdersPage() {
   const [filter,      setFilter]      = useState('incomplete')
   const [selected,    setSelected]    = useState(null)
   const [lastRefresh, setLastRefresh] = useState(new Date())
+  const [now,         setNow]         = useState(new Date())
   const timerRef = useRef(null)
+  const clockRef = useRef(null)
 
   const load = useCallback(async () => {
     try {
@@ -144,7 +169,8 @@ export default function OrdersPage() {
   useEffect(() => {
     load()
     timerRef.current = setInterval(load, 30000)
-    return () => clearInterval(timerRef.current)
+    clockRef.current = setInterval(() => setNow(new Date()), 15000)
+    return () => { clearInterval(timerRef.current); clearInterval(clockRef.current) }
   }, [load])
 
   const handleStatusChange = async (orderId, newStatus) => {
@@ -198,6 +224,7 @@ export default function OrdersPage() {
                 <th>주문번호</th>
                 <th>유형</th>
                 <th>상태</th>
+                <th>경과</th>
                 <th>결제</th>
                 <th>금액(시각)</th>
                 <th>상태변경</th>
@@ -205,7 +232,7 @@ export default function OrdersPage() {
             </thead>
             <tbody>
               {filtered.length === 0 && (
-                <tr><td colSpan={6} className="loading-text">주문이 없습니다</td></tr>
+                <tr><td colSpan={7} className="loading-text">주문이 없습니다</td></tr>
               )}
               {filtered.map(order => {
                 const next = nextStatus(order.status)
@@ -220,6 +247,12 @@ export default function OrdersPage() {
                     <td className="order-number">#{order.order_number}</td>
                     <td>{order.order_type === 'EAT_IN' ? '매장' : '포장'}</td>
                     <td><StatusBadge value={order.status} /></td>
+                    <td>
+                      {ELAPSED_ACTIVE.has(order.status) && order.created_at
+                        ? <ElapsedBadge createdAt={order.created_at} now={now} />
+                        : <span style={{ color: '#ccc', fontSize: 12 }}>–</span>
+                      }
+                    </td>
                     <td><StatusBadge type="payment" value={order.payment_status ?? 'PENDING'} /></td>
                     <td>
                       <span style={{ fontWeight:'500' }}>{Number(order.final_amount).toLocaleString('ko-KR')}원</span>

--- a/frontend/src/admin/pages/OrdersPage.jsx
+++ b/frontend/src/admin/pages/OrdersPage.jsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useRef } from 'react'
-import { DUMMY_ORDERS } from '../api/adminApi.js'
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { fetchAdminOrders, updateOrderStatus } from '../api/adminApi.js'
 import StatusBadge from '../components/StatusBadge.jsx'
 
 const STATUS_FILTERS = [
@@ -20,16 +20,17 @@ function nextStatus(current) {
 }
 
 function nextLabel(status) {
-  const map = { RECEIVED: '조리중으로', COOKING: '준비완료로', READY: '완료로' }
-  return map[status]
+  return { RECEIVED: '조리중으로', COOKING: '준비완료로', READY: '완료로' }[status]
 }
 
 function fmt(dt) {
+  if (!dt) return ''
   const d = new Date(dt)
   return `${d.getHours().toString().padStart(2,'0')}:${d.getMinutes().toString().padStart(2,'0')}`
 }
 
 function fmtFull(dt) {
+  if (!dt) return ''
   const d = new Date(dt)
   return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')} ${d.getHours().toString().padStart(2,'0')}:${d.getMinutes().toString().padStart(2,'0')}`
 }
@@ -58,7 +59,7 @@ function OrderDetail({ order, onClose, onStatusChange }) {
           <div key={i}>
             <div style={{ display:'flex', justifyContent:'space-between', fontWeight:'500', marginBottom:'4px' }}>
               <span>{item.name_ko} X{item.quantity}</span>
-              <span>{(item.total_price).toLocaleString('ko-KR')}원</span>
+              <span>{Number(item.total_price).toLocaleString('ko-KR')}원</span>
             </div>
             {item.selected_options?.length > 0 && (
               <div style={{ fontSize:'12px', color:'#888', paddingLeft:'8px', lineHeight:'1.8' }}>
@@ -82,24 +83,24 @@ function OrderDetail({ order, onClose, onStatusChange }) {
       <div style={{ display:'flex', flexDirection:'column', gap:'8px', fontSize:'14px' }}>
         <div style={{ display:'flex', justifyContent:'space-between' }}>
           <span style={{ color:'#888' }}>주문 금액</span>
-          <span>{order.subtotal.toLocaleString('ko-KR')}원</span>
+          <span>{Number(order.subtotal).toLocaleString('ko-KR')}원</span>
         </div>
-        {order.discount_amount > 0 && (
+        {Number(order.discount_amount) > 0 && (
           <div style={{ display:'flex', justifyContent:'space-between' }}>
             <span style={{ color:'#888' }}>할인</span>
-            <span style={{ color:'#e00' }}>-{order.discount_amount.toLocaleString('ko-KR')}원</span>
+            <span style={{ color:'#e00' }}>-{Number(order.discount_amount).toLocaleString('ko-KR')}원</span>
           </div>
         )}
-        {order.points_used > 0 && (
+        {Number(order.points_used) > 0 && (
           <div style={{ display:'flex', justifyContent:'space-between' }}>
             <span style={{ color:'#888' }}>포인트 사용</span>
-            <span style={{ color:'#e00' }}>-{order.points_used.toLocaleString('ko-KR')}P</span>
+            <span style={{ color:'#e00' }}>-{Number(order.points_used).toLocaleString('ko-KR')}P</span>
           </div>
         )}
         <div className="divider" style={{ margin:'4px 0' }} />
         <div style={{ display:'flex', justifyContent:'space-between', fontWeight:'700', fontSize:'15px' }}>
           <span>결제금액</span>
-          <span>{order.final_amount.toLocaleString('ko-KR')}원</span>
+          <span>{Number(order.final_amount).toLocaleString('ko-KR')}원</span>
         </div>
       </div>
 
@@ -119,35 +120,56 @@ function OrderDetail({ order, onClose, onStatusChange }) {
 }
 
 export default function OrdersPage() {
-  const [orders, setOrders] = useState(DUMMY_ORDERS)
-  const [filter, setFilter] = useState('incomplete')
-  const [selected, setSelected] = useState(null)
+  const [orders,      setOrders]      = useState([])
+  const [loading,     setLoading]     = useState(true)
+  const [error,       setError]       = useState('')
+  const [filter,      setFilter]      = useState('incomplete')
+  const [selected,    setSelected]    = useState(null)
   const [lastRefresh, setLastRefresh] = useState(new Date())
   const timerRef = useRef(null)
 
-  useEffect(() => {
-    timerRef.current = setInterval(() => setLastRefresh(new Date()), 30000)
-    return () => clearInterval(timerRef.current)
+  const load = useCallback(async () => {
+    try {
+      const data = await fetchAdminOrders()
+      setOrders(data)
+      setLastRefresh(new Date())
+      setError('')
+    } catch (e) {
+      setError(e.message)
+    } finally {
+      setLoading(false)
+    }
   }, [])
 
-  const handleStatusChange = (orderId, newStatus) => {
-    setOrders(prev => prev.map(o =>
-      o.order_id === orderId ? { ...o, status: newStatus } : o
-    ))
-    setSelected(prev => prev?.order_id === orderId ? { ...prev, status: newStatus } : prev)
+  useEffect(() => {
+    load()
+    timerRef.current = setInterval(load, 30000)
+    return () => clearInterval(timerRef.current)
+  }, [load])
+
+  const handleStatusChange = async (orderId, newStatus) => {
+    try {
+      const updated = await updateOrderStatus(orderId, newStatus)
+      setOrders(prev => prev.map(o => o.order_id === orderId ? updated : o))
+      setSelected(prev => prev?.order_id === orderId ? updated : prev)
+    } catch (e) {
+      alert(`상태 변경 실패: ${e.message}`)
+    }
   }
 
   const filtered = orders.filter(o => {
-    if (filter === 'all') return true
+    if (filter === 'all')        return true
     if (filter === 'incomplete') return ['RECEIVED','COOKING','READY'].includes(o.status)
     return o.status === filter
   })
 
-  const selectedOrder = selected ? orders.find(o => o.order_id === selected.order_id) : null
+  const selectedOrder = selected ? orders.find(o => o.order_id === selected.order_id) ?? null : null
+
+  if (loading) return <div className="loading-text">주문 로딩 중…</div>
+  if (error)   return <div className="loading-text" style={{ color:'#c00' }}>{error}</div>
 
   return (
     <div>
-      {/* Toolbar */}
       <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginBottom:'16px' }}>
         <div className="filter-chips">
           {STATUS_FILTERS.map(f => (
@@ -160,13 +182,15 @@ export default function OrdersPage() {
             </button>
           ))}
         </div>
-        <span style={{ fontSize:'12px', color:'#aaa', whiteSpace:'nowrap', marginLeft:'16px' }}>
-          마지막 갱신 {lastRefresh.getHours().toString().padStart(2,'0')}:{lastRefresh.getMinutes().toString().padStart(2,'0')}:{lastRefresh.getSeconds().toString().padStart(2,'0')}
-        </span>
+        <div style={{ display:'flex', alignItems:'center', gap:'10px' }}>
+          <span style={{ fontSize:'12px', color:'#aaa', whiteSpace:'nowrap' }}>
+            마지막 갱신 {lastRefresh.getHours().toString().padStart(2,'0')}:{lastRefresh.getMinutes().toString().padStart(2,'0')}:{lastRefresh.getSeconds().toString().padStart(2,'0')}
+          </span>
+          <button className="btn-outline btn-sm" onClick={load}>새로고침</button>
+        </div>
       </div>
 
-      <div style={{ display:'flex', alignItems:'flex-start', gap:'0' }}>
-        {/* Table */}
+      <div style={{ display:'flex', alignItems:'flex-start' }}>
         <div className="card" style={{ flex:1, padding:'0', overflow:'hidden' }}>
           <table className="data-table">
             <thead>
@@ -175,7 +199,7 @@ export default function OrdersPage() {
                 <th>유형</th>
                 <th>상태</th>
                 <th>결제</th>
-                <th>금액(생성시각)</th>
+                <th>금액(시각)</th>
                 <th>상태변경</th>
               </tr>
             </thead>
@@ -198,7 +222,7 @@ export default function OrdersPage() {
                     <td><StatusBadge value={order.status} /></td>
                     <td><StatusBadge type="payment" value={order.payment_status ?? 'PENDING'} /></td>
                     <td>
-                      <span style={{ fontWeight:'500' }}>{order.final_amount.toLocaleString('ko-KR')}원</span>
+                      <span style={{ fontWeight:'500' }}>{Number(order.final_amount).toLocaleString('ko-KR')}원</span>
                       <span style={{ color:'#bbb', marginLeft:'6px', fontSize:'12px' }}>{fmt(order.created_at)}</span>
                     </td>
                     <td onClick={e => e.stopPropagation()}>
@@ -213,9 +237,9 @@ export default function OrdersPage() {
                           <button
                             className="chip"
                             style={{ padding:'3px 10px', fontSize:'11px' }}
-                            onClick={() => handleStatusChange(order.order_id, 'CANCELLED')}
+                            onClick={() => { if (confirm('주문을 취소하시겠습니까?')) handleStatusChange(order.order_id, 'CANCELLED') }}
                           >
-                            ···
+                            취소
                           </button>
                         </div>
                       ) : (
@@ -231,7 +255,6 @@ export default function OrdersPage() {
           </table>
         </div>
 
-        {/* Detail panel */}
         {selectedOrder && (
           <OrderDetail
             order={selectedOrder}

--- a/frontend/src/admin/pages/OrdersPage.jsx
+++ b/frontend/src/admin/pages/OrdersPage.jsx
@@ -218,7 +218,16 @@ export default function OrdersPage() {
 
       <div style={{ display:'flex', alignItems:'flex-start' }}>
         <div className="card" style={{ flex:1, padding:'0', overflow:'hidden' }}>
-          <table className="data-table">
+          <table className="data-table" style={{ tableLayout:'fixed', width:'100%' }}>
+            <colgroup>
+              <col style={{ width: 90 }} />
+              <col style={{ width: 60 }} />
+              <col style={{ width: 100 }} />
+              <col style={{ width: 72 }} />
+              <col style={{ width: 88 }} />
+              <col />
+              <col style={{ width: 170 }} />
+            </colgroup>
             <thead>
               <tr>
                 <th>주문번호</th>

--- a/frontend/src/admin/pages/OrdersPage.jsx
+++ b/frontend/src/admin/pages/OrdersPage.jsx
@@ -1,0 +1,245 @@
+import { useState, useEffect, useRef } from 'react'
+import { DUMMY_ORDERS } from '../api/adminApi.js'
+import StatusBadge from '../components/StatusBadge.jsx'
+
+const STATUS_FILTERS = [
+  { key: 'incomplete', label: '미완료' },
+  { key: 'all',        label: '전체' },
+  { key: 'RECEIVED',   label: '접수' },
+  { key: 'COOKING',    label: '조리중' },
+  { key: 'READY',      label: '준비완료' },
+  { key: 'COMPLETED',  label: '완료됨' },
+  { key: 'CANCELLED',  label: '취소됨' },
+]
+
+const ORDER_STATUSES = ['RECEIVED', 'COOKING', 'READY', 'COMPLETED']
+
+function nextStatus(current) {
+  const idx = ORDER_STATUSES.indexOf(current)
+  return idx >= 0 && idx < ORDER_STATUSES.length - 1 ? ORDER_STATUSES[idx + 1] : null
+}
+
+function nextLabel(status) {
+  const map = { RECEIVED: '조리중으로', COOKING: '준비완료로', READY: '완료로' }
+  return map[status]
+}
+
+function fmt(dt) {
+  const d = new Date(dt)
+  return `${d.getHours().toString().padStart(2,'0')}:${d.getMinutes().toString().padStart(2,'0')}`
+}
+
+function fmtFull(dt) {
+  const d = new Date(dt)
+  return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')} ${d.getHours().toString().padStart(2,'0')}:${d.getMinutes().toString().padStart(2,'0')}`
+}
+
+function OrderDetail({ order, onClose, onStatusChange }) {
+  if (!order) return null
+  const next = nextStatus(order.status)
+
+  return (
+    <div className="detail-panel" style={{ marginLeft: '16px' }}>
+      <button className="detail-panel-close" onClick={onClose}>×</button>
+      <div style={{ display:'flex', alignItems:'center', gap:'10px', marginBottom:'16px' }}>
+        <span className="order-number" style={{ fontSize:'16px' }}>#{order.order_number}</span>
+        <StatusBadge value={order.status} />
+      </div>
+      <div style={{ fontSize:'13px', color:'#999', marginBottom:'20px' }}>
+        {order.order_type === 'EAT_IN'
+          ? `매장 · ${order.table_number != null ? order.table_number+'번 테이블' : '테이블 미지정'}`
+          : '포장'}
+        &nbsp;·&nbsp;{fmtFull(order.created_at)}
+      </div>
+
+      <div style={{ fontWeight:'700', fontSize:'14px', marginBottom:'12px' }}>주문 항목</div>
+      <div style={{ display:'flex', flexDirection:'column', gap:'14px', marginBottom:'20px' }}>
+        {order.items.map((item, i) => (
+          <div key={i}>
+            <div style={{ display:'flex', justifyContent:'space-between', fontWeight:'500', marginBottom:'4px' }}>
+              <span>{item.name_ko} X{item.quantity}</span>
+              <span>{(item.total_price).toLocaleString('ko-KR')}원</span>
+            </div>
+            {item.selected_options?.length > 0 && (
+              <div style={{ fontSize:'12px', color:'#888', paddingLeft:'8px', lineHeight:'1.8' }}>
+                {item.selected_options.map((o,j) => <div key={j}>{o}</div>)}
+              </div>
+            )}
+            {item.special_note && (
+              <div style={{ marginTop:'4px' }}>
+                <span style={{
+                  display:'inline-block', fontSize:'11px', padding:'2px 8px',
+                  background:'#fff3e0', color:'#b87800', borderRadius:'4px', fontWeight:'600'
+                }}>{item.special_note}</span>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div className="divider" />
+      <div style={{ fontWeight:'700', fontSize:'14px', marginBottom:'12px' }}>결제 정보</div>
+      <div style={{ display:'flex', flexDirection:'column', gap:'8px', fontSize:'14px' }}>
+        <div style={{ display:'flex', justifyContent:'space-between' }}>
+          <span style={{ color:'#888' }}>주문 금액</span>
+          <span>{order.subtotal.toLocaleString('ko-KR')}원</span>
+        </div>
+        {order.discount_amount > 0 && (
+          <div style={{ display:'flex', justifyContent:'space-between' }}>
+            <span style={{ color:'#888' }}>할인</span>
+            <span style={{ color:'#e00' }}>-{order.discount_amount.toLocaleString('ko-KR')}원</span>
+          </div>
+        )}
+        {order.points_used > 0 && (
+          <div style={{ display:'flex', justifyContent:'space-between' }}>
+            <span style={{ color:'#888' }}>포인트 사용</span>
+            <span style={{ color:'#e00' }}>-{order.points_used.toLocaleString('ko-KR')}P</span>
+          </div>
+        )}
+        <div className="divider" style={{ margin:'4px 0' }} />
+        <div style={{ display:'flex', justifyContent:'space-between', fontWeight:'700', fontSize:'15px' }}>
+          <span>결제금액</span>
+          <span>{order.final_amount.toLocaleString('ko-KR')}원</span>
+        </div>
+      </div>
+
+      {next && order.status !== 'CANCELLED' && (
+        <div style={{ marginTop:'20px' }}>
+          <button
+            className="btn-primary"
+            style={{ width:'100%', padding:'12px', fontSize:'14px' }}
+            onClick={() => onStatusChange(order.order_id, next)}
+          >
+            {nextLabel(order.status)}으로 변경
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function OrdersPage() {
+  const [orders, setOrders] = useState(DUMMY_ORDERS)
+  const [filter, setFilter] = useState('incomplete')
+  const [selected, setSelected] = useState(null)
+  const [lastRefresh, setLastRefresh] = useState(new Date())
+  const timerRef = useRef(null)
+
+  useEffect(() => {
+    timerRef.current = setInterval(() => setLastRefresh(new Date()), 30000)
+    return () => clearInterval(timerRef.current)
+  }, [])
+
+  const handleStatusChange = (orderId, newStatus) => {
+    setOrders(prev => prev.map(o =>
+      o.order_id === orderId ? { ...o, status: newStatus } : o
+    ))
+    setSelected(prev => prev?.order_id === orderId ? { ...prev, status: newStatus } : prev)
+  }
+
+  const filtered = orders.filter(o => {
+    if (filter === 'all') return true
+    if (filter === 'incomplete') return ['RECEIVED','COOKING','READY'].includes(o.status)
+    return o.status === filter
+  })
+
+  const selectedOrder = selected ? orders.find(o => o.order_id === selected.order_id) : null
+
+  return (
+    <div>
+      {/* Toolbar */}
+      <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginBottom:'16px' }}>
+        <div className="filter-chips">
+          {STATUS_FILTERS.map(f => (
+            <button
+              key={f.key}
+              className={`chip${filter === f.key ? ' active' : ''}`}
+              onClick={() => setFilter(f.key)}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+        <span style={{ fontSize:'12px', color:'#aaa', whiteSpace:'nowrap', marginLeft:'16px' }}>
+          마지막 갱신 {lastRefresh.getHours().toString().padStart(2,'0')}:{lastRefresh.getMinutes().toString().padStart(2,'0')}:{lastRefresh.getSeconds().toString().padStart(2,'0')}
+        </span>
+      </div>
+
+      <div style={{ display:'flex', alignItems:'flex-start', gap:'0' }}>
+        {/* Table */}
+        <div className="card" style={{ flex:1, padding:'0', overflow:'hidden' }}>
+          <table className="data-table">
+            <thead>
+              <tr>
+                <th>주문번호</th>
+                <th>유형</th>
+                <th>상태</th>
+                <th>결제</th>
+                <th>금액(생성시각)</th>
+                <th>상태변경</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.length === 0 && (
+                <tr><td colSpan={6} className="loading-text">주문이 없습니다</td></tr>
+              )}
+              {filtered.map(order => {
+                const next = nextStatus(order.status)
+                const isSelected = selectedOrder?.order_id === order.order_id
+                return (
+                  <tr
+                    key={order.order_id}
+                    className={isSelected ? 'selected' : ''}
+                    style={{ cursor:'pointer' }}
+                    onClick={() => setSelected(isSelected ? null : order)}
+                  >
+                    <td className="order-number">#{order.order_number}</td>
+                    <td>{order.order_type === 'EAT_IN' ? '매장' : '포장'}</td>
+                    <td><StatusBadge value={order.status} /></td>
+                    <td><StatusBadge type="payment" value={order.payment_status ?? 'PENDING'} /></td>
+                    <td>
+                      <span style={{ fontWeight:'500' }}>{order.final_amount.toLocaleString('ko-KR')}원</span>
+                      <span style={{ color:'#bbb', marginLeft:'6px', fontSize:'12px' }}>{fmt(order.created_at)}</span>
+                    </td>
+                    <td onClick={e => e.stopPropagation()}>
+                      {next && order.status !== 'CANCELLED' ? (
+                        <div style={{ display:'flex', gap:'6px', alignItems:'center' }}>
+                          <button
+                            className="btn-primary btn-sm"
+                            onClick={() => handleStatusChange(order.order_id, next)}
+                          >
+                            {nextLabel(order.status)} →
+                          </button>
+                          <button
+                            className="chip"
+                            style={{ padding:'3px 10px', fontSize:'11px' }}
+                            onClick={() => handleStatusChange(order.order_id, 'CANCELLED')}
+                          >
+                            ···
+                          </button>
+                        </div>
+                      ) : (
+                        <span className="btn-disabled btn-sm">
+                          {order.status === 'COMPLETED' ? '완료됨' : '취소됨'}
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Detail panel */}
+        {selectedOrder && (
+          <OrderDetail
+            order={selectedOrder}
+            onClose={() => setSelected(null)}
+            onStatusChange={handleStatusChange}
+          />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/admin/pages/PaymentsPage.jsx
+++ b/frontend/src/admin/pages/PaymentsPage.jsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { DUMMY_PAYMENTS } from '../api/adminApi.js'
+import { useState, useEffect } from 'react'
+import { fetchAdminPayments, refundPayment } from '../api/adminApi.js'
 import StatusBadge from '../components/StatusBadge.jsx'
 
 const FILTERS = [
@@ -10,16 +10,27 @@ const FILTERS = [
   { key: 'REFUNDED', label: '환불됨' },
 ]
 
+function fmtDatetime(dt) {
+  if (!dt) return '–'
+  const d = new Date(dt)
+  return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')} ${d.getHours().toString().padStart(2,'0')}:${d.getMinutes().toString().padStart(2,'0')}`
+}
+
 function RefundModal({ payment, onClose, onConfirm }) {
-  const [reason, setReason] = useState('')
+  const [reason, setReason]   = useState('')
   const [loading, setLoading] = useState(false)
 
   const handleConfirm = async () => {
     if (!reason.trim()) { alert('환불 사유를 입력해 주세요'); return }
     setLoading(true)
-    await onConfirm(payment.payment_id, reason)
-    setLoading(false)
-    onClose()
+    try {
+      await onConfirm(payment.payment_id, reason)
+      onClose()
+    } catch (e) {
+      alert(`환불 실패: ${e.message}`)
+    } finally {
+      setLoading(false)
+    }
   }
 
   return (
@@ -28,7 +39,7 @@ function RefundModal({ payment, onClose, onConfirm }) {
         <div className="modal-title">환불 처리</div>
         <p style={{ fontSize:'13px', color:'#666', marginBottom:'16px' }}>
           주문 <strong className="order-number">#{payment.order_number}</strong>의 결제
-          ({payment.amount.toLocaleString('ko-KR')}원)를 환불합니다.
+          ({Number(payment.amount).toLocaleString('ko-KR')}원)를 환불합니다.
         </p>
         <div style={{
           background:'#fff8e1', border:'1px solid #ffe082',
@@ -59,25 +70,36 @@ function RefundModal({ payment, onClose, onConfirm }) {
 }
 
 export default function PaymentsPage() {
-  const [payments, setPayments] = useState(DUMMY_PAYMENTS)
-  const [filter, setFilter] = useState('all')
+  const [payments,     setPayments]     = useState([])
+  const [loading,      setLoading]      = useState(true)
+  const [error,        setError]        = useState('')
+  const [filter,       setFilter]       = useState('all')
   const [refundTarget, setRefundTarget] = useState(null)
 
-  const handleRefund = (paymentId, reason) => {
-    setPayments(prev => prev.map(p =>
-      p.payment_id === paymentId
-        ? { ...p, status: 'REFUNDED', failure_reason: reason, refunded_at: new Date().toLocaleTimeString('ko-KR', { hour:'2-digit', minute:'2-digit' }) }
-        : p
-    ))
+  const load = () => {
+    setLoading(true)
+    fetchAdminPayments()
+      .then(data => { setPayments(data); setError('') })
+      .catch(e => setError(e.message))
+      .finally(() => setLoading(false))
+  }
+
+  useEffect(() => { load() }, [])
+
+  const handleRefund = async (paymentId, reason) => {
+    const updated = await refundPayment(paymentId, reason)
+    setPayments(prev => prev.map(p => p.payment_id === paymentId ? updated : p))
   }
 
   const filtered = payments.filter(p =>
     filter === 'all' || p.status === filter
   )
 
+  if (loading) return <div className="loading-text">결제 내역 로딩 중…</div>
+  if (error)   return <div className="loading-text" style={{ color:'#c00' }}>{error}</div>
+
   return (
     <div>
-      {/* Filters */}
       <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginBottom:'16px' }}>
         <div className="filter-chips">
           {FILTERS.map(f => (
@@ -90,24 +112,19 @@ export default function PaymentsPage() {
             </button>
           ))}
         </div>
-        <div style={{
-          border:'1.5px solid #ddd', borderRadius:'8px', padding:'6px 14px',
-          fontSize:'13px', color:'#666', background:'#fff'
-        }}>
-          2026-07-{String(new Date().getDate()-6).padStart(2,'0')} ~ 07-{String(new Date().getDate()).padStart(2,'0')}
-        </div>
+        <button className="btn-outline btn-sm" onClick={load}>새로고침</button>
       </div>
 
       <div className="card" style={{ padding:0, overflow:'hidden' }}>
         <table className="data-table">
           <thead>
             <tr>
-              <th>결제ID</th>
               <th>주문번호</th>
               <th>수단</th>
               <th>금액/상태</th>
               <th>실패/환불사유</th>
               <th>결제시각</th>
+              <th>환불시각</th>
               <th>환불</th>
             </tr>
           </thead>
@@ -117,25 +134,20 @@ export default function PaymentsPage() {
             )}
             {filtered.map(p => (
               <tr key={p.payment_id}>
-                <td style={{ color:'#888', fontSize:'13px' }}>{p.payment_id}</td>
                 <td className="order-number">#{p.order_number}</td>
                 <td>{p.method}</td>
                 <td>
-                  <span style={{ marginRight:'8px' }}>{p.amount.toLocaleString('ko-KR')}원</span>
+                  <span style={{ marginRight:'8px' }}>{Number(p.amount).toLocaleString('ko-KR')}원</span>
                   <StatusBadge type="payment" value={p.status} />
                 </td>
                 <td style={{ color: p.failure_reason ? '#c0392b' : '#ccc', fontSize:'13px' }}>
                   {p.failure_reason ?? '–'}
                 </td>
-                <td style={{ color:'#888', fontSize:'13px' }}>{p.paid_at}</td>
+                <td style={{ color:'#888', fontSize:'13px' }}>{fmtDatetime(p.paid_at)}</td>
+                <td style={{ color:'#888', fontSize:'13px' }}>{p.refunded_at ? fmtDatetime(p.refunded_at) : '–'}</td>
                 <td>
                   {p.status === 'SUCCESS' ? (
-                    <button
-                      className="btn-danger btn-sm"
-                      onClick={() => setRefundTarget(p)}
-                    >
-                      환불
-                    </button>
+                    <button className="btn-danger btn-sm" onClick={() => setRefundTarget(p)}>환불</button>
                   ) : (
                     <button className="btn-disabled btn-sm" disabled>환불</button>
                   )}

--- a/frontend/src/admin/pages/PaymentsPage.jsx
+++ b/frontend/src/admin/pages/PaymentsPage.jsx
@@ -1,0 +1,158 @@
+import { useState } from 'react'
+import { DUMMY_PAYMENTS } from '../api/adminApi.js'
+import StatusBadge from '../components/StatusBadge.jsx'
+
+const FILTERS = [
+  { key: 'all',      label: '전체' },
+  { key: 'PENDING',  label: '대기' },
+  { key: 'SUCCESS',  label: '완료' },
+  { key: 'FAILED',   label: '실패' },
+  { key: 'REFUNDED', label: '환불됨' },
+]
+
+function RefundModal({ payment, onClose, onConfirm }) {
+  const [reason, setReason] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const handleConfirm = async () => {
+    if (!reason.trim()) { alert('환불 사유를 입력해 주세요'); return }
+    setLoading(true)
+    await onConfirm(payment.payment_id, reason)
+    setLoading(false)
+    onClose()
+  }
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-box">
+        <div className="modal-title">환불 처리</div>
+        <p style={{ fontSize:'13px', color:'#666', marginBottom:'16px' }}>
+          주문 <strong className="order-number">#{payment.order_number}</strong>의 결제
+          ({payment.amount.toLocaleString('ko-KR')}원)를 환불합니다.
+        </p>
+        <div style={{
+          background:'#fff8e1', border:'1px solid #ffe082',
+          borderRadius:'8px', padding:'10px 14px',
+          fontSize:'12px', color:'#795548', marginBottom:'16px'
+        }}>
+          ⚠️ 환불 시 포인트·쿠폰이 함께 원상복구됩니다. 이 작업은 되돌릴 수 없습니다.
+        </div>
+        <div className="form-group">
+          <label className="form-label">환불 사유</label>
+          <input
+            className="form-input"
+            value={reason}
+            onChange={e => setReason(e.target.value)}
+            placeholder="예: 고객 변심, 품질 불량 등"
+            autoFocus
+          />
+        </div>
+        <div className="modal-footer">
+          <button className="btn-outline" onClick={onClose}>취소</button>
+          <button className="btn-danger" onClick={handleConfirm} disabled={loading}>
+            {loading ? '처리 중…' : '환불 확인'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function PaymentsPage() {
+  const [payments, setPayments] = useState(DUMMY_PAYMENTS)
+  const [filter, setFilter] = useState('all')
+  const [refundTarget, setRefundTarget] = useState(null)
+
+  const handleRefund = (paymentId, reason) => {
+    setPayments(prev => prev.map(p =>
+      p.payment_id === paymentId
+        ? { ...p, status: 'REFUNDED', failure_reason: reason, refunded_at: new Date().toLocaleTimeString('ko-KR', { hour:'2-digit', minute:'2-digit' }) }
+        : p
+    ))
+  }
+
+  const filtered = payments.filter(p =>
+    filter === 'all' || p.status === filter
+  )
+
+  return (
+    <div>
+      {/* Filters */}
+      <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginBottom:'16px' }}>
+        <div className="filter-chips">
+          {FILTERS.map(f => (
+            <button
+              key={f.key}
+              className={`chip${filter === f.key ? ' active' : ''}`}
+              onClick={() => setFilter(f.key)}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+        <div style={{
+          border:'1.5px solid #ddd', borderRadius:'8px', padding:'6px 14px',
+          fontSize:'13px', color:'#666', background:'#fff'
+        }}>
+          2026-07-{String(new Date().getDate()-6).padStart(2,'0')} ~ 07-{String(new Date().getDate()).padStart(2,'0')}
+        </div>
+      </div>
+
+      <div className="card" style={{ padding:0, overflow:'hidden' }}>
+        <table className="data-table">
+          <thead>
+            <tr>
+              <th>결제ID</th>
+              <th>주문번호</th>
+              <th>수단</th>
+              <th>금액/상태</th>
+              <th>실패/환불사유</th>
+              <th>결제시각</th>
+              <th>환불</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.length === 0 && (
+              <tr><td colSpan={7} className="loading-text">결제 내역이 없습니다</td></tr>
+            )}
+            {filtered.map(p => (
+              <tr key={p.payment_id}>
+                <td style={{ color:'#888', fontSize:'13px' }}>{p.payment_id}</td>
+                <td className="order-number">#{p.order_number}</td>
+                <td>{p.method}</td>
+                <td>
+                  <span style={{ marginRight:'8px' }}>{p.amount.toLocaleString('ko-KR')}원</span>
+                  <StatusBadge type="payment" value={p.status} />
+                </td>
+                <td style={{ color: p.failure_reason ? '#c0392b' : '#ccc', fontSize:'13px' }}>
+                  {p.failure_reason ?? '–'}
+                </td>
+                <td style={{ color:'#888', fontSize:'13px' }}>{p.paid_at}</td>
+                <td>
+                  {p.status === 'SUCCESS' ? (
+                    <button
+                      className="btn-danger btn-sm"
+                      onClick={() => setRefundTarget(p)}
+                    >
+                      환불
+                    </button>
+                  ) : (
+                    <button className="btn-disabled btn-sm" disabled>환불</button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {refundTarget && (
+        <RefundModal
+          payment={refundTarget}
+          onClose={() => setRefundTarget(null)}
+          onConfirm={handleRefund}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/admin/pages/UsersPage.jsx
+++ b/frontend/src/admin/pages/UsersPage.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { listUsers, getUserDetail, adjustPoints } from '../api/adminApi.js'
+import { listUsers, getUserDetail, adjustPoints, updateUserTier } from '../api/adminApi.js'
 import StatusBadge from '../components/StatusBadge.jsx'
 
 const TIER_COLORS = {
@@ -81,7 +81,49 @@ function PointsModal({ user, onClose, onConfirm }) {
   )
 }
 
-function UserDetail({ user, onPointsAdjust }) {
+function TierModal({ user, onClose, onConfirm }) {
+  const [tier, setTier] = useState(user.tier ?? 'BASIC')
+  const [loading, setLoading] = useState(false)
+
+  const handleConfirm = async () => {
+    setLoading(true)
+    try {
+      await onConfirm(tier)
+      onClose()
+    } catch (e) {
+      alert(e.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-box">
+        <div className="modal-title">회원 등급 변경</div>
+        <p style={{ fontSize:'13px', color:'#666', marginBottom:'16px' }}>
+          <strong>{user.phone_number}</strong> &nbsp; 현재 등급: <TierBadge tier={user.tier} />
+        </p>
+        <div className="form-group">
+          <label className="form-label">변경할 등급</label>
+          <select className="form-input" value={tier} onChange={e => setTier(e.target.value)}>
+            <option value="BASIC">BASIC</option>
+            <option value="SILVER">SILVER</option>
+            <option value="GOLD">GOLD</option>
+          </select>
+        </div>
+        <div className="modal-footer">
+          <button className="btn-outline" onClick={onClose}>취소</button>
+          <button className="btn-primary" onClick={handleConfirm} disabled={loading}>
+            {loading ? '변경 중…' : '변경'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function UserDetail({ user, onPointsAdjust, onTierChange }) {
   if (!user) return null
 
   return (
@@ -92,6 +134,11 @@ function UserDetail({ user, onPointsAdjust }) {
           <div style={{ display:'flex', alignItems:'center', gap:'10px' }}>
             <span style={{ fontWeight:'700', fontSize:'16px' }}>{user.phone_number ?? '알 수 없음'}</span>
             <TierBadge tier={user.tier} />
+            {!user.is_guest && (
+              <button className="btn-outline btn-sm" style={{ fontSize:11 }} onClick={onTierChange}>
+                등급 변경
+              </button>
+            )}
           </div>
           <span style={{ fontSize:'12px', color:'#aaa' }}>
             가입일 {user.created_at ? new Date(user.created_at).toLocaleDateString('ko-KR', { year:'numeric', month:'2-digit', day:'2-digit' }).replace(/\. /g,'.').replace('.','/').replace('.','/') : '–'}
@@ -173,6 +220,7 @@ export default function UsersPage() {
   const [searching, setSearching] = useState(false)
   const [loadingDetail, setLoadingDetail] = useState(false)
   const [showPointsModal, setShowPointsModal] = useState(false)
+  const [showTierModal,   setShowTierModal]   = useState(false)
   const [error, setError] = useState('')
 
   const handleSearch = async () => {
@@ -208,9 +256,15 @@ export default function UsersPage() {
   const handlePointsAdjust = async (delta, reason) => {
     if (!selectedUser) return
     const updated = await adjustPoints(selectedUser.id, delta, reason)
-    // refresh detail
     setDetailUser(prev => prev ? { ...prev, current_points: updated.current_points } : prev)
     setUsers(prev => prev.map(u => u.id === selectedUser.id ? { ...u, current_points: updated.current_points } : u))
+  }
+
+  const handleTierUpdate = async (tier) => {
+    if (!selectedUser) return
+    const updated = await updateUserTier(selectedUser.id, tier)
+    setDetailUser(prev => prev ? { ...prev, tier: updated.tier } : prev)
+    setUsers(prev => prev.map(u => u.id === selectedUser.id ? { ...u, tier: updated.tier } : u))
   }
 
   const handleKeyDown = (e) => {
@@ -288,6 +342,7 @@ export default function UsersPage() {
           <UserDetail
             user={detailUser}
             onPointsAdjust={() => setShowPointsModal(true)}
+            onTierChange={() => setShowTierModal(true)}
           />
         )}
       </div>
@@ -297,6 +352,14 @@ export default function UsersPage() {
           user={detailUser}
           onClose={() => setShowPointsModal(false)}
           onConfirm={handlePointsAdjust}
+        />
+      )}
+
+      {showTierModal && detailUser && (
+        <TierModal
+          user={detailUser}
+          onClose={() => setShowTierModal(false)}
+          onConfirm={handleTierUpdate}
         />
       )}
     </div>

--- a/frontend/src/admin/pages/UsersPage.jsx
+++ b/frontend/src/admin/pages/UsersPage.jsx
@@ -1,0 +1,304 @@
+import { useState } from 'react'
+import { listUsers, getUserDetail, adjustPoints } from '../api/adminApi.js'
+import StatusBadge from '../components/StatusBadge.jsx'
+
+const TIER_COLORS = {
+  BASIC:  { bg:'#e8f5e9', color:'#2e7d32' },
+  SILVER: { bg:'#e8eaf6', color:'#3949ab' },
+  GOLD:   { bg:'#fff8e1', color:'#f57f17' },
+  VIP:    { bg:'linear-gradient(135deg,#ff6b6b,#ffd93d,#6bcb77)', color:'#fff' },
+}
+
+function TierBadge({ tier }) {
+  if (!tier) return <span className="badge badge-inactive">비회원</span>
+  const style = TIER_COLORS[tier] ?? { bg:'#f5f5f5', color:'#888' }
+  return (
+    <span style={{
+      display:'inline-block', padding:'2px 10px', borderRadius:'999px',
+      fontSize:'12px', fontWeight:'700',
+      background: style.bg, color: style.color,
+    }}>
+      {tier}
+    </span>
+  )
+}
+
+function PointsModal({ user, onClose, onConfirm }) {
+  const [delta, setDelta] = useState('')
+  const [reason, setReason] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const handleConfirm = async () => {
+    const d = parseInt(delta, 10)
+    if (isNaN(d) || d === 0) { alert('조정할 포인트 값을 입력해 주세요'); return }
+    if (!reason.trim()) { alert('조정 사유를 입력해 주세요'); return }
+    setLoading(true)
+    try {
+      await onConfirm(d, reason)
+      onClose()
+    } catch (e) {
+      alert(e.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-box">
+        <div className="modal-title">포인트 조정</div>
+        <p style={{ fontSize:'13px', color:'#666', marginBottom:'16px' }}>
+          <strong>{user.phone_number}</strong> 현재 보유 포인트: <strong>{user.current_points.toLocaleString('ko-KR')}P</strong>
+        </p>
+        <div className="form-group">
+          <label className="form-label">조정값 (양수: 적립, 음수: 차감)</label>
+          <input
+            className="form-input"
+            type="number"
+            value={delta}
+            onChange={e => setDelta(e.target.value)}
+            placeholder="예: 500 (적립) 또는 -200 (차감)"
+            autoFocus
+          />
+        </div>
+        <div className="form-group">
+          <label className="form-label">조정 사유 <span style={{color:'#e00'}}>*</span></label>
+          <input
+            className="form-input"
+            value={reason}
+            onChange={e => setReason(e.target.value)}
+            placeholder="예: 이벤트 보상, 운영자 수동 조정 등"
+          />
+        </div>
+        <div className="modal-footer">
+          <button className="btn-outline" onClick={onClose}>취소</button>
+          <button className="btn-primary" onClick={handleConfirm} disabled={loading}>
+            {loading ? '저장 중…' : '확인'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function UserDetail({ user, onPointsAdjust }) {
+  if (!user) return null
+
+  return (
+    <div style={{ display:'flex', flexDirection:'column', gap:'16px' }}>
+      {/* Points card */}
+      <div className="card">
+        <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginBottom:'4px' }}>
+          <div style={{ display:'flex', alignItems:'center', gap:'10px' }}>
+            <span style={{ fontWeight:'700', fontSize:'16px' }}>{user.phone_number ?? '알 수 없음'}</span>
+            <TierBadge tier={user.tier} />
+          </div>
+          <span style={{ fontSize:'12px', color:'#aaa' }}>
+            가입일 {user.created_at ? new Date(user.created_at).toLocaleDateString('ko-KR', { year:'numeric', month:'2-digit', day:'2-digit' }).replace(/\. /g,'.').replace('.','/').replace('.','/') : '–'}
+          </span>
+        </div>
+        <div style={{ marginTop:'14px', display:'flex', alignItems:'center', justifyContent:'space-between' }}>
+          <div>
+            <div style={{ fontSize:'12px', color:'#aaa', marginBottom:'4px' }}>현재 포인트</div>
+            <div style={{ fontSize:'26px', fontWeight:'700', color:'#744032' }}>
+              {user.current_points.toLocaleString('ko-KR')} P
+            </div>
+          </div>
+          <button className="btn-primary" onClick={onPointsAdjust}>포인트 조정</button>
+        </div>
+      </div>
+
+      {/* Recent orders */}
+      {user.recent_orders?.length > 0 && (
+        <div className="card">
+          <div style={{ fontWeight:'700', fontSize:'14px', marginBottom:'14px' }}>최근 주문 내역</div>
+          <table className="data-table">
+            <thead>
+              <tr>
+                <th>주문번호</th>
+                <th>유형</th>
+                <th>상태</th>
+                <th>결제</th>
+                <th style={{ textAlign:'right' }}>금액(생성시각)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {user.recent_orders.map(order => (
+                <tr key={order.order_id}>
+                  <td className="order-number">#{order.order_number}</td>
+                  <td>{order.order_type === 'EAT_IN' ? '매장' : '포장'}</td>
+                  <td><StatusBadge value={order.status} /></td>
+                  <td><StatusBadge type="payment" value={order.payment_status ?? 'PENDING'} /></td>
+                  <td style={{ textAlign:'right' }}>
+                    <span style={{ fontWeight:'500' }}>{order.final_amount.toLocaleString('ko-KR')}원</span>
+                    <span style={{ color:'#bbb', marginLeft:'6px', fontSize:'11px' }}>
+                      {order.created_at ? new Date(order.created_at).toLocaleTimeString('ko-KR', { hour:'2-digit', minute:'2-digit' }) : ''}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Coupons */}
+      {user.coupons?.length > 0 && (
+        <div className="card">
+          <div style={{ fontWeight:'700', fontSize:'14px', marginBottom:'14px' }}>보유 쿠폰</div>
+          <div style={{ display:'flex', gap:'8px', flexWrap:'wrap' }}>
+            {user.coupons.map(uc => (
+              <span key={uc.user_coupon_id} style={{
+                display:'inline-block', padding:'5px 12px',
+                border:'1px solid #ddd', borderRadius:'8px',
+                fontSize:'12px', color:'#444',
+                background: uc.is_used ? '#f5f5f5' : '#fff',
+              }}>
+                쿠폰 {uc.coupon_id?.slice(0,8)}
+                {uc.is_used && <span style={{ color:'#bbb', marginLeft:'4px' }}>(사용됨)</span>}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function UsersPage() {
+  const [phone, setPhone] = useState('')
+  const [users, setUsers] = useState([])
+  const [selectedUser, setSelectedUser] = useState(null)
+  const [detailUser, setDetailUser] = useState(null)
+  const [searching, setSearching] = useState(false)
+  const [loadingDetail, setLoadingDetail] = useState(false)
+  const [showPointsModal, setShowPointsModal] = useState(false)
+  const [error, setError] = useState('')
+
+  const handleSearch = async () => {
+    setError('')
+    setSearching(true)
+    try {
+      const data = await listUsers(phone || undefined)
+      setUsers(data)
+      setSelectedUser(null)
+      setDetailUser(null)
+    } catch (e) {
+      setError(e.message)
+    } finally {
+      setSearching(false)
+    }
+  }
+
+  const handleSelectUser = async (user) => {
+    setSelectedUser(user)
+    setDetailUser(null)
+    setLoadingDetail(true)
+    try {
+      const detail = await getUserDetail(user.id)
+      setDetailUser(detail)
+    } catch (e) {
+      // fallback: show basic info
+      setDetailUser({ ...user, recent_orders: [], coupons: [] })
+    } finally {
+      setLoadingDetail(false)
+    }
+  }
+
+  const handlePointsAdjust = async (delta, reason) => {
+    if (!selectedUser) return
+    const updated = await adjustPoints(selectedUser.id, delta, reason)
+    // refresh detail
+    setDetailUser(prev => prev ? { ...prev, current_points: updated.current_points } : prev)
+    setUsers(prev => prev.map(u => u.id === selectedUser.id ? { ...u, current_points: updated.current_points } : u))
+  }
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') handleSearch()
+  }
+
+  return (
+    <div style={{ display:'flex', gap:'16px', alignItems:'flex-start' }}>
+      {/* Left: search + list */}
+      <div style={{ width:300, minWidth:300, display:'flex', flexDirection:'column', gap:'12px' }}>
+        {/* Search */}
+        <div style={{ display:'flex', gap:'8px' }}>
+          <input
+            className="form-input"
+            value={phone}
+            onChange={e => setPhone(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="전화번호 입력"
+            style={{ flex:1 }}
+          />
+          <button
+            className="btn-primary"
+            onClick={handleSearch}
+            disabled={searching}
+            style={{ whiteSpace:'nowrap' }}
+          >
+            {searching ? '…' : '검색'}
+          </button>
+        </div>
+
+        {error && <div style={{ color:'#c00', fontSize:'13px' }}>{error}</div>}
+
+        {/* User list */}
+        <div className="card" style={{ padding:'8px 0', minHeight:120 }}>
+          {users.length === 0 && !searching && (
+            <div className="loading-text" style={{ padding:'24px 0' }}>
+              전화번호로 검색하세요
+            </div>
+          )}
+          {users.map(user => (
+            <div
+              key={user.id}
+              onClick={() => handleSelectUser(user)}
+              style={{
+                padding:'12px 16px',
+                cursor:'pointer',
+                background: selectedUser?.id === user.id ? '#fff5f0' : 'transparent',
+                borderLeft: selectedUser?.id === user.id ? '3px solid #744032' : '3px solid transparent',
+              }}
+            >
+              <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginBottom:'3px' }}>
+                <span style={{ fontWeight:'600', fontSize:'14px' }}>{user.phone_number ?? '비회원'}</span>
+                <TierBadge tier={user.tier} />
+              </div>
+              <div style={{ fontSize:'12px', color:'#999' }}>
+                포인트 {user.current_points.toLocaleString('ko-KR')}P
+                {user.created_at && (
+                  <span style={{ marginLeft:'8px' }}>
+                    · 가입일 {new Date(user.created_at).toLocaleDateString('ko-KR')}
+                  </span>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Right: detail */}
+      <div style={{ flex:1, minWidth:0 }}>
+        {loadingDetail && <div className="loading-text">회원 정보 로딩 중…</div>}
+        {!loadingDetail && !detailUser && (
+          <div className="loading-text">회원을 검색하고 선택하세요</div>
+        )}
+        {!loadingDetail && detailUser && (
+          <UserDetail
+            user={detailUser}
+            onPointsAdjust={() => setShowPointsModal(true)}
+          />
+        )}
+      </div>
+
+      {showPointsModal && detailUser && (
+        <PointsModal
+          user={detailUser}
+          onClose={() => setShowPointsModal(false)}
+          onConfirm={handlePointsAdjust}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/CouponScanModal.jsx
+++ b/frontend/src/components/CouponScanModal.jsx
@@ -1,27 +1,35 @@
 import { useEffect, useRef, useState } from 'react'
 import { BrowserMultiFormatReader } from '@zxing/browser'
+import { validateCoupon } from '../services/orderService'
 
-// QR/바코드 스캔 + 수동 입력 겸용 쿠폰 코드 입력 모달.
-// 카메라 권한이 없거나 인식이 안 되는 경우를 대비해 수동 입력을 항상 함께 제공한다.
-export default function CouponScanModal({ onDetect, onClose }) {
-  const videoRef = useRef(null)
+// QR/바코드 스캔 + 수동 입력 겸용 쿠폰 입력 → 검증 → 확인 모달
+// onDetect(code, validationInfo): 사용하기 버튼 클릭 시 호출
+export default function CouponScanModal({ onDetect, onClose, total }) {
+  const videoRef  = useRef(null)
   const readerRef = useRef(null)
-  const [manualCode, setManualCode] = useState('')
-  const [cameraError, setCameraError] = useState('')
-  const [scanning, setScanning] = useState(true)
+
+  const [manualCode,   setManualCode]   = useState('')
+  const [cameraError,  setCameraError]  = useState('')
+  const [scanning,     setScanning]     = useState(true)
+  const [checking,     setChecking]     = useState(false)
+  const [confirmed,    setConfirmed]    = useState(null)  // { code, info } — 확인 단계
+  const [checkError,   setCheckError]   = useState('')
+
+  const stopCamera = () => {
+    try { readerRef.current?.reset?.() } catch { /* ignore */ }
+  }
 
   useEffect(() => {
     let stopped = false
     const reader = new BrowserMultiFormatReader()
     readerRef.current = reader
 
-    reader.decodeFromVideoDevice(undefined, videoRef.current, (result, err) => {
-      if (stopped) return
+    reader.decodeFromVideoDevice(undefined, videoRef.current, (result) => {
+      if (stopped || confirmed) return
       if (result) {
         stopped = true
-        onDetect(result.getText())
+        handleVerify(result.getText())
       }
-      // NotFoundException은 매 프레임마다 정상적으로 발생(아직 인식 못 함) — 무시.
     }).catch(err => {
       if (stopped) return
       console.error('[CouponScanModal] 카메라 시작 실패:', err)
@@ -31,14 +39,43 @@ export default function CouponScanModal({ onDetect, onClose }) {
 
     return () => {
       stopped = true
-      try { readerRef.current?.reset?.() } catch { /* ignore */ }
+      stopCamera()
     }
-  }, [onDetect])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
-  const handleManualSubmit = () => {
-    const code = manualCode.trim()
-    if (!code) return
-    onDetect(code)
+  const handleVerify = async (code) => {
+    const trimmed = code.trim().toUpperCase()
+    if (!trimmed) return
+    setCheckError('')
+    setChecking(true)
+    stopCamera()
+    try {
+      const info = await validateCoupon(trimmed, total)
+      if (!info.valid) {
+        setCheckError(info.message || '유효하지 않은 쿠폰입니다')
+        setChecking(false)
+        return
+      }
+      setConfirmed({ code: trimmed, info })
+    } catch (e) {
+      setCheckError(e.message || '쿠폰 확인에 실패했습니다')
+    } finally {
+      setChecking(false)
+    }
+  }
+
+  const handleManualSubmit = () => handleVerify(manualCode)
+
+  const handleApply = () => {
+    if (!confirmed) return
+    onDetect(confirmed.code, confirmed.info)
+  }
+
+  const handleRetry = () => {
+    setConfirmed(null)
+    setCheckError('')
+    setManualCode('')
+    setScanning(true)
   }
 
   return (
@@ -56,53 +93,131 @@ export default function CouponScanModal({ onDetect, onClose }) {
         display: 'flex', flexDirection: 'column', gap: 16,
       }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-          <span style={{ fontSize: 20, fontWeight: 900 }}>쿠폰 QR·바코드 스캔</span>
+          <span style={{ fontSize: 20, fontWeight: 900 }}>
+            {confirmed ? '쿠폰 확인' : '쿠폰 QR·바코드 스캔'}
+          </span>
           <button onClick={onClose} style={{
             background: 'none', border: 'none', fontSize: 22, cursor: 'pointer', color: '#999',
           }}>✕</button>
         </div>
 
-        {scanning && !cameraError && (
-          <div style={{
-            position: 'relative', width: '100%', aspectRatio: '4 / 3',
-            background: '#000', borderRadius: 12, overflow: 'hidden',
-          }}>
-            <video ref={videoRef} style={{ width: '100%', height: '100%', objectFit: 'cover' }} muted playsInline />
+        {/* ── 확인 단계 ── */}
+        {confirmed && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
             <div style={{
-              position: 'absolute', inset: '15% 20%', border: '3px solid #F5B800',
-              borderRadius: 10, pointerEvents: 'none',
-            }} />
+              background: '#fff8f0', border: '1.5px solid #f0e0c8',
+              borderRadius: 12, padding: '18px 20px',
+              display: 'flex', flexDirection: 'column', gap: 10,
+            }}>
+              <div style={{ fontSize: 16, fontWeight: 700, color: '#744032' }}>
+                쿠폰 코드: <span style={{ fontFamily: 'monospace' }}>{confirmed.code}</span>
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 15 }}>
+                <span style={{ color: '#666' }}>할인 금액</span>
+                <span style={{ fontWeight: 700, color: '#2e7d32' }}>
+                  −{confirmed.info.discountAmount.toLocaleString('ko-KR')}원
+                </span>
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 15 }}>
+                <span style={{ color: '#666' }}>최종 결제 금액</span>
+                <span style={{ fontWeight: 900, fontSize: 18, color: '#744032' }}>
+                  {confirmed.info.finalAmount.toLocaleString('ko-KR')}원
+                  {confirmed.info.finalAmount === 0 && (
+                    <span style={{ fontSize: 13, color: '#2e7d32', marginLeft: 6 }}>(무료)</span>
+                  )}
+                </span>
+              </div>
+            </div>
+            <div style={{ display: 'flex', gap: 10 }}>
+              <button
+                onClick={handleRetry}
+                style={{
+                  flex: 1, padding: '16px', border: '1.5px solid #e0e0e0', borderRadius: 12,
+                  background: '#f5f5f5', color: '#555', fontSize: 15, fontWeight: 700, cursor: 'pointer',
+                }}
+              >
+                다시 입력
+              </button>
+              <button
+                onClick={handleApply}
+                style={{
+                  flex: 1, padding: '16px', border: 'none', borderRadius: 12,
+                  background: '#744032', color: '#fff', fontSize: 15, fontWeight: 700, cursor: 'pointer',
+                }}
+              >
+                사용하기
+              </button>
+            </div>
           </div>
         )}
 
-        {cameraError && (
-          <p style={{ fontSize: 14, color: '#e44', fontWeight: 600, margin: 0 }}>{cameraError}</p>
-        )}
+        {/* ── 입력/스캔 단계 ── */}
+        {!confirmed && (
+          <>
+            {/* 카메라 뷰 */}
+            {scanning && !cameraError && (
+              <div style={{
+                position: 'relative', width: '100%', aspectRatio: '4 / 3',
+                background: '#000', borderRadius: 12, overflow: 'hidden',
+              }}>
+                <video ref={videoRef} style={{ width: '100%', height: '100%', objectFit: 'cover' }} muted playsInline />
+                <div style={{
+                  position: 'absolute', inset: '15% 20%', border: '3px solid #F5B800',
+                  borderRadius: 10, pointerEvents: 'none',
+                }} />
+                {checking && (
+                  <div style={{
+                    position: 'absolute', inset: 0, background: 'rgba(0,0,0,0.5)',
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    color: '#fff', fontSize: 16, fontWeight: 700,
+                  }}>
+                    쿠폰 확인 중…
+                  </div>
+                )}
+              </div>
+            )}
 
-        <div style={{ display: 'flex', gap: 8 }}>
-          <input
-            type="text"
-            value={manualCode}
-            onChange={e => setManualCode(e.target.value)}
-            onKeyDown={e => { if (e.key === 'Enter') handleManualSubmit() }}
-            placeholder="쿠폰 코드 직접 입력"
-            style={{
-              flex: 1, boxSizing: 'border-box', border: '1.5px solid #e0e0e0',
-              borderRadius: 10, padding: '12px 14px', fontSize: 15,
-            }}
-          />
-          <button
-            onClick={handleManualSubmit}
-            disabled={!manualCode.trim()}
-            style={{
-              border: 'none', borderRadius: 10, padding: '0 20px',
-              background: manualCode.trim() ? '#744032' : '#e0e0e0',
-              color: manualCode.trim() ? '#fff' : '#999',
-              fontSize: 14, fontWeight: 700,
-              cursor: manualCode.trim() ? 'pointer' : 'default',
-            }}
-          >입력</button>
-        </div>
+            {cameraError && (
+              <p style={{ fontSize: 14, color: '#e44', fontWeight: 600, margin: 0 }}>{cameraError}</p>
+            )}
+
+            {/* 수동 입력 */}
+            <div style={{ display: 'flex', gap: 8 }}>
+              <input
+                type="text"
+                value={manualCode}
+                onChange={e => setManualCode(e.target.value.toUpperCase())}
+                onKeyDown={e => { if (e.key === 'Enter') handleManualSubmit() }}
+                placeholder="쿠폰 코드 직접 입력"
+                disabled={checking}
+                style={{
+                  flex: 1, boxSizing: 'border-box', border: '1.5px solid #e0e0e0',
+                  borderRadius: 10, padding: '12px 14px', fontSize: 15,
+                }}
+              />
+              <button
+                onClick={handleManualSubmit}
+                disabled={!manualCode.trim() || checking}
+                style={{
+                  border: 'none', borderRadius: 10, padding: '0 20px',
+                  background: (manualCode.trim() && !checking) ? '#744032' : '#e0e0e0',
+                  color: (manualCode.trim() && !checking) ? '#fff' : '#999',
+                  fontSize: 14, fontWeight: 700,
+                  cursor: (manualCode.trim() && !checking) ? 'pointer' : 'default',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {checking ? '확인 중…' : '입력'}
+              </button>
+            </div>
+
+            {checkError && (
+              <p style={{ fontSize: 13, color: '#e44', fontWeight: 600, margin: 0 }}>
+                {checkError}
+              </p>
+            )}
+          </>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/data/menuData.js
+++ b/frontend/src/data/menuData.js
@@ -43,20 +43,20 @@ export const menuItems = {
 }
 
 export const SET_SIDES = [
-  { name: '감자튀김',    nameEn: 'Fries',          nameJa: 'フライドポテト',    nameZh: '薯条',     extra: 0, image: '/images/sides/감튀.webp' },
-  { name: '치즈스틱',   nameEn: 'Cheese Sticks',  nameJa: 'チーズスティック',  nameZh: '芝士棒',   extra: 0, image: '/images/sides/치즈스틱.webp' },
-  { name: '치킨너겟',   nameEn: 'Nuggets',        nameJa: 'チキンナゲット',    nameZh: '鸡块',     extra: 0, image: '/images/sides/너겟.webp' },
-  { name: '양념감자튀김', nameEn: 'Seasoned Fries', nameJa: 'ヤンニョムポテト', nameZh: '辣味薯条', extra: 0, image: '/images/sides/양념감튀.webp' },
+  { name: '감자튀김',    nameEn: 'Fries',          nameJa: 'フライドポテト',    nameZh: '薯条',     extra:   0, image: '/images/sides/감튀.webp' },
+  { name: '치즈스틱',   nameEn: 'Cheese Sticks',  nameJa: 'チーズスティック',  nameZh: '芝士棒',   extra:   0, image: '/images/sides/치즈스틱.webp' },
+  { name: '치킨너겟',   nameEn: 'Nuggets',        nameJa: 'チキンナゲット',    nameZh: '鸡块',     extra:   0, image: '/images/sides/너겟.webp' },
+  { name: '양념감자튀김', nameEn: 'Seasoned Fries', nameJa: 'ヤンニョムポテト', nameZh: '辣味薯条', extra: 500, image: '/images/sides/양념감튀.webp' },
 ]
 
 export const SET_DRINKS = [
-  { name: '콜라',       nameEn: 'Cola',             nameJa: 'コーラ',           nameZh: '可乐',     extra: 0, image: '/images/drinks/콜라.webp' },
-  { name: '제로콜라',   nameEn: 'Zero-Sugar Cola',  nameJa: 'ゼロコーラ',       nameZh: '零糖可乐', extra: 0, image: '/images/drinks/콜라.webp' },
-  { name: '사이다',     nameEn: 'Cider',            nameJa: 'サイダー',         nameZh: '雪碧',     extra: 0, image: '/images/drinks/사이다.webp' },
-  { name: '제로사이다', nameEn: 'Zero-Sugar Cider', nameJa: 'ゼロサイダー',     nameZh: '零糖雪碧', extra: 0, image: '/images/drinks/사이다.webp' },
-  { name: '생수',       nameEn: 'Water',            nameJa: 'お水',             nameZh: '矿泉水',   extra: 0, image: '/images/drinks/생수.webp' },
-  { name: '뽀로로음료', nameEn: 'Pororo Drink',     nameJa: 'ポロロドリンク',   nameZh: '啵乐乐',   extra: 0, image: '/images/drinks/뽀로로음료.webp' },
-  { name: '오렌지주스', nameEn: 'Orange Juice',     nameJa: 'オレンジジュース', nameZh: '橙汁',     extra: 0, image: '/images/drinks/오렌지주스.webp' },
+  { name: '콜라',       nameEn: 'Cola',             nameJa: 'コーラ',           nameZh: '可乐',     extra:   0, image: '/images/drinks/콜라.webp' },
+  { name: '제로콜라',   nameEn: 'Zero-Sugar Cola',  nameJa: 'ゼロコーラ',       nameZh: '零糖可乐', extra:   0, image: '/images/drinks/콜라.webp' },
+  { name: '사이다',     nameEn: 'Cider',            nameJa: 'サイダー',         nameZh: '雪碧',     extra:   0, image: '/images/drinks/사이다.webp' },
+  { name: '제로사이다', nameEn: 'Zero-Sugar Cider', nameJa: 'ゼロサイダー',     nameZh: '零糖雪碧', extra:   0, image: '/images/drinks/사이다.webp' },
+  { name: '생수',       nameEn: 'Water',            nameJa: 'お水',             nameZh: '矿泉水',   extra:   0, image: '/images/drinks/생수.webp' },
+  { name: '뽀로로음료', nameEn: 'Pororo Drink',     nameJa: 'ポロロドリンク',   nameZh: '啵乐乐',   extra:   0, image: '/images/drinks/뽀로로음료.webp' },
+  { name: '오렌지주스', nameEn: 'Orange Juice',     nameJa: 'オレンジジュース', nameZh: '橙汁',     extra: 500, image: '/images/drinks/오렌지주스.webp' },
 ]
 
 export const SET_SURCHARGE = 2000

--- a/frontend/src/screens/CartScreen.jsx
+++ b/frontend/src/screens/CartScreen.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import Logo from '../components/Logo'
 import { lookupCustomer } from '../services/pointsService'
-import { createOrder, validateCoupon } from '../services/orderService'
+import { createOrder, validateCoupon, previewDiscount } from '../services/orderService'
 import { processPayment } from '../services/paymentService'
 import { triggerHardwareAction } from '../services/hardwareService'
 import IdleOverlay from '../components/IdleOverlay'
@@ -55,6 +55,7 @@ export default function CartScreen({ cart, total, updateQty, clearCart, nav, set
   const [couponInfo,       setCouponInfo]       = useState(null)   // { valid, message, discountAmount? }
   const [couponChecking,   setCouponChecking]   = useState(false)
   const [showCouponScan,   setShowCouponScan]   = useState(false)
+  const [discountPreview,  setDiscountPreview]  = useState(null)  // { discountAmount, applicable }
 
   const isCompletingRef = useRef(false)
 
@@ -200,20 +201,24 @@ export default function CartScreen({ cart, total, updateQty, clearCart, nav, set
     return () => { if (voiceRef) voiceRef.current = null }
   }, [voiceRef, cart, total])  // eslint-disable-line react-hooks/exhaustive-deps
 
+  // 카트가 바뀔 때마다 적용 가능한 할인 미리보기
+  useEffect(() => {
+    if (cart.length === 0) { setDiscountPreview(null); return }
+    previewDiscount().then(r => setDiscountPreview(r.discountAmount > 0 ? r : null))
+  }, [cart.length])
+
   const handleComplete = async () => {
     if (isCompletingRef.current) return
     isCompletingRef.current = true
     setPaymentError('')
     try {
-      const { orderId, orderNum } = await createOrder({
+      const { orderId, orderNum, finalAmount: serverFinalAmount } = await createOrder({
         orderType,
         phone: confirmedPhone.replace(/\D/g, '') || null,
         couponCode: couponCode.trim() || null,
       })
-      // 쿠폰 적용 후 실제 결제 금액 계산 (서버가 계산한 finalAmount 우선, 없으면 클라이언트 계산)
-      const payAmount = couponInfo?.valid
-        ? (couponInfo.finalAmount ?? Math.max(0, total - (couponInfo.discountAmount ?? 0)))
-        : total
+      // 서버가 반환한 finalAmount 사용 (쿠폰 + Discount 테이블 할인 모두 반영됨)
+      const payAmount = serverFinalAmount ?? 0
       // 결제 금액이 0원이면 결제 API 호출 없이 완료 처리
       if (payAmount > 0) {
         const { success } = await processPayment({ orderId, method: paymentMethod, amount: payAmount })
@@ -302,6 +307,23 @@ export default function CartScreen({ cart, total, updateQty, clearCart, nav, set
         background: '#fff', borderTop: '2px solid #ddd',
         padding: '16px 20px', flexShrink: 0,
       }}>
+        {discountPreview && (
+          <div style={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+            <span style={{ fontSize: 14, color: '#e44', fontWeight: 600 }}>
+              할인 -{discountPreview.discountAmount.toLocaleString('ko-KR')}원
+            </span>
+            <span style={{ fontSize: 12, color: '#aaa' }}>
+              ({discountPreview.applicable.map(a => a.name).join(', ')})
+            </span>
+          </div>
+        )}
+        {couponInfo?.valid && (
+          <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 6 }}>
+            <span style={{ fontSize: 14, color: '#e44', fontWeight: 600 }}>
+              쿠폰 -{(couponInfo.discountAmount ?? 0).toLocaleString('ko-KR')}원
+            </span>
+          </div>
+        )}
         <div style={{
           display: 'flex', justifyContent: 'flex-end', alignItems: 'baseline',
           gap: 14, marginBottom: 16,
@@ -526,7 +548,7 @@ export default function CartScreen({ cart, total, updateQty, clearCart, nav, set
       {showCardPayment && (
         <PayWaitPopup
           title={t('waitCard')}
-          total={couponInfo?.valid ? (couponInfo.finalAmount ?? Math.max(0, total - (couponInfo.discountAmount ?? 0))) : total}
+          total={Math.max(0, total - (couponInfo?.valid ? (couponInfo.discountAmount ?? 0) : 0) - (discountPreview?.discountAmount ?? 0))}
           image={PAYMENT_IMAGES.cardWait}
           onCancel={() => { setShowCardPayment(false); setShowPaymentPopup(true) }}
           onComplete={handleComplete}
@@ -540,7 +562,7 @@ export default function CartScreen({ cart, total, updateQty, clearCart, nav, set
       {showCashPayment && (
         <PayWaitPopup
           title={t('waitCash')}
-          total={couponInfo?.valid ? (couponInfo.finalAmount ?? Math.max(0, total - (couponInfo.discountAmount ?? 0))) : total}
+          total={Math.max(0, total - (couponInfo?.valid ? (couponInfo.discountAmount ?? 0) : 0) - (discountPreview?.discountAmount ?? 0))}
           image={PAYMENT_IMAGES.cashWait}
           onCancel={() => { setShowCashPayment(false); setShowPaymentPopup(true) }}
           onComplete={handleComplete}
@@ -554,7 +576,7 @@ export default function CartScreen({ cart, total, updateQty, clearCart, nav, set
       {showPayPayment && (
         <PayWaitPopup
           title={t('waitPay')}
-          total={couponInfo?.valid ? (couponInfo.finalAmount ?? Math.max(0, total - (couponInfo.discountAmount ?? 0))) : total}
+          total={Math.max(0, total - (couponInfo?.valid ? (couponInfo.discountAmount ?? 0) : 0) - (discountPreview?.discountAmount ?? 0))}
           image={PAYMENT_IMAGES.payWait}
           onCancel={() => { setShowPayPayment(false); setShowPaymentPopup(true) }}
           onComplete={handleComplete}

--- a/frontend/src/screens/CartScreen.jsx
+++ b/frontend/src/screens/CartScreen.jsx
@@ -1,7 +1,7 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useMemo } from 'react'
 import Logo from '../components/Logo'
 import { lookupCustomer } from '../services/pointsService'
-import { createOrder, validateCoupon, previewDiscount } from '../services/orderService'
+import { createOrder, validateCoupon, previewDiscount, fetchActiveDiscounts } from '../services/orderService'
 import { processPayment } from '../services/paymentService'
 import { triggerHardwareAction } from '../services/hardwareService'
 import IdleOverlay from '../components/IdleOverlay'
@@ -12,6 +12,27 @@ import { useLocale } from '../i18n/LocaleContext'
 import { SET_SIDES, SET_DRINKS } from '../data/menuData'
 
 const POINT_KEYS = ['1','2','3','4','5','6','7','8','9','지움','0','010']
+
+function computeItemDiscount(itemId, categoryId, unitPrice, activeDiscounts) {
+  if (!activeDiscounts?.length) return null
+  const today = new Date().toISOString().split('T')[0]
+  let price = unitPrice
+  for (const d of activeDiscounts) {
+    if (!d.is_active) continue
+    if (d.applicable_tier !== 'ALL') continue
+    if (d.valid_from && today < d.valid_from) continue
+    if (d.valid_until && today > d.valid_until) continue
+    const matches =
+      d.target_type === 'ALL' ||
+      (d.target_type === 'MENU' && d.menu_item_id === itemId) ||
+      (d.target_type === 'CATEGORY' && d.category_id === categoryId)
+    if (!matches) continue
+    if (d.discount_type === 'PERCENT') price = Math.round(price * (1 - Number(d.discount_value) / 100))
+    else price = Math.max(0, price - Number(d.discount_value))
+  }
+  if (price === unitPrice) return null
+  return { discountedPrice: price, savings: unitPrice - price }
+}
 
 // 결제 수단 이미지 경로 — null 이면 기존 이모티콘/텍스트 폴백 표시
 // 예: card: '/assets/payment/card.png'
@@ -56,6 +77,7 @@ export default function CartScreen({ cart, total, updateQty, clearCart, nav, set
   const [couponChecking,   setCouponChecking]   = useState(false)
   const [showCouponScan,   setShowCouponScan]   = useState(false)
   const [discountPreview,  setDiscountPreview]  = useState(null)  // { discountAmount, applicable }
+  const [activeDiscounts,  setActiveDiscounts]  = useState([])
 
   const isCompletingRef = useRef(false)
 
@@ -207,6 +229,10 @@ export default function CartScreen({ cart, total, updateQty, clearCart, nav, set
     previewDiscount().then(r => setDiscountPreview(r.discountAmount > 0 ? r : null))
   }, [cart.length])
 
+  useEffect(() => {
+    fetchActiveDiscounts().then(setActiveDiscounts)
+  }, [])
+
   const handleComplete = async () => {
     if (isCompletingRef.current) return
     isCompletingRef.current = true
@@ -296,9 +322,17 @@ export default function CartScreen({ cart, total, updateQty, clearCart, nav, set
             {t('cartEmpty')}
           </div>
         ) : (
-          cart.map(item => (
-            <CartItem key={item.cartId} item={item} onUpdateQty={updateQty} />
-          ))
+          cart.map(item => {
+            const disc = computeItemDiscount(item.id, item.categoryId ?? null, item.unitPrice, activeDiscounts)
+            return (
+              <CartItem
+                key={item.cartId}
+                item={item}
+                onUpdateQty={updateQty}
+                discountedUnitPrice={disc ? disc.discountedPrice : null}
+              />
+            )
+          })
         )}
       </div>
 
@@ -737,7 +771,7 @@ function translateOptionName(korName, locale) {
 }
 
 /* ── CartItem ── */
-function CartItem({ item, onUpdateQty }) {
+function CartItem({ item, onUpdateQty, discountedUnitPrice }) {
   const t = useT()
   const { locale } = useLocale()
   const hasOptions = (item.exclusion && item.exclusion !== '없음') || item.side || item.drink
@@ -780,7 +814,18 @@ function CartItem({ item, onUpdateQty }) {
           display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 8,
           alignSelf: 'center',
         }}>
-          <span style={{ fontSize: 18, fontWeight: 800 }}>{(item.unitPrice * item.qty).toLocaleString()}{t('won')}</span>
+          {discountedUnitPrice != null && discountedUnitPrice < item.unitPrice ? (
+            <span style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 1 }}>
+              <span style={{ fontSize: 14, color: '#bbb', textDecoration: 'line-through', fontWeight: 400 }}>
+                {(item.unitPrice * item.qty).toLocaleString()}{t('won')}
+              </span>
+              <span style={{ fontSize: 18, fontWeight: 800, color: '#e44' }}>
+                {(discountedUnitPrice * item.qty).toLocaleString()}{t('won')}
+              </span>
+            </span>
+          ) : (
+            <span style={{ fontSize: 18, fontWeight: 800 }}>{(item.unitPrice * item.qty).toLocaleString()}{t('won')}</span>
+          )}
           <button onClick={() => onUpdateQty(item.cartId, 0)} style={{
             background: 'none', border: 'none', color: '#bbb',
             fontSize: 20, lineHeight: 1, cursor: 'pointer', padding: 0, flexShrink: 0,

--- a/frontend/src/screens/CartScreen.jsx
+++ b/frontend/src/screens/CartScreen.jsx
@@ -139,11 +139,15 @@ export default function CartScreen({ cart, total, updateQty, clearCart, nav, set
     }
   }
 
-  // QR/바코드 스캔 또는 모달 내 수동 입력 완료 시 호출됨
-  const handleCouponDetected = (code) => {
+  // CouponScanModal에서 검증+확인 완료 후 호출됨 (code, validatedInfo)
+  const handleCouponDetected = (code, info) => {
     setShowCouponScan(false)
     setCouponCode(code)
-    handleCheckCoupon(code)
+    if (info) {
+      setCouponInfo(info)
+    } else {
+      handleCheckCoupon(code)
+    }
   }
 
   const goPayment = (dest) => {
@@ -571,6 +575,7 @@ export default function CartScreen({ cart, total, updateQty, clearCart, nav, set
         <CouponScanModal
           onDetect={handleCouponDetected}
           onClose={() => setShowCouponScan(false)}
+          total={total}
         />
       )}
 

--- a/frontend/src/screens/CartScreen.jsx
+++ b/frontend/src/screens/CartScreen.jsx
@@ -206,8 +206,15 @@ export default function CartScreen({ cart, total, updateQty, clearCart, nav, set
         phone: confirmedPhone.replace(/\D/g, '') || null,
         couponCode: couponCode.trim() || null,
       })
-      const { success } = await processPayment({ orderId, method: paymentMethod, amount: total })
-      if (!success) throw new Error('결제가 승인되지 않았습니다')
+      // 쿠폰 적용 후 실제 결제 금액 계산 (서버가 계산한 finalAmount 우선, 없으면 클라이언트 계산)
+      const payAmount = couponInfo?.valid
+        ? (couponInfo.finalAmount ?? Math.max(0, total - (couponInfo.discountAmount ?? 0)))
+        : total
+      // 결제 금액이 0원이면 결제 API 호출 없이 완료 처리
+      if (payAmount > 0) {
+        const { success } = await processPayment({ orderId, method: paymentMethod, amount: payAmount })
+        if (!success) throw new Error('결제가 승인되지 않았습니다')
+      }
       setShowCardPayment(false)
       setShowCashPayment(false)
       setShowPayPayment(false)

--- a/frontend/src/screens/CartScreen.jsx
+++ b/frontend/src/screens/CartScreen.jsx
@@ -526,7 +526,7 @@ export default function CartScreen({ cart, total, updateQty, clearCart, nav, set
       {showCardPayment && (
         <PayWaitPopup
           title={t('waitCard')}
-          total={total}
+          total={couponInfo?.valid ? (couponInfo.finalAmount ?? Math.max(0, total - (couponInfo.discountAmount ?? 0))) : total}
           image={PAYMENT_IMAGES.cardWait}
           onCancel={() => { setShowCardPayment(false); setShowPaymentPopup(true) }}
           onComplete={handleComplete}
@@ -540,7 +540,7 @@ export default function CartScreen({ cart, total, updateQty, clearCart, nav, set
       {showCashPayment && (
         <PayWaitPopup
           title={t('waitCash')}
-          total={total}
+          total={couponInfo?.valid ? (couponInfo.finalAmount ?? Math.max(0, total - (couponInfo.discountAmount ?? 0))) : total}
           image={PAYMENT_IMAGES.cashWait}
           onCancel={() => { setShowCashPayment(false); setShowPaymentPopup(true) }}
           onComplete={handleComplete}
@@ -554,7 +554,7 @@ export default function CartScreen({ cart, total, updateQty, clearCart, nav, set
       {showPayPayment && (
         <PayWaitPopup
           title={t('waitPay')}
-          total={total}
+          total={couponInfo?.valid ? (couponInfo.finalAmount ?? Math.max(0, total - (couponInfo.discountAmount ?? 0))) : total}
           image={PAYMENT_IMAGES.payWait}
           onCancel={() => { setShowPayPayment(false); setShowPaymentPopup(true) }}
           onComplete={handleComplete}

--- a/frontend/src/screens/MenuScreen.jsx
+++ b/frontend/src/screens/MenuScreen.jsx
@@ -1,4 +1,4 @@
-﻿import { useState, useEffect, useRef, useCallback } from 'react'
+﻿import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import Logo from '../components/Logo'
 import ReturnToStartDialog from '../components/ReturnToStartDialog'
 import SingleSetModal from '../components/SingleSetModal'
@@ -9,6 +9,35 @@ import useT from '../i18n/useT'
 
 const COLS = 3
 const GRID_GAP = 9
+
+// 아이템에 적용되는 모든 할인을 합산해 할인된 단가 정보를 반환한다.
+// 할인이 없으면 null 반환.
+function computeItemDiscount(itemId, categoryId, unitPrice, activeDiscounts) {
+  if (!activeDiscounts?.length) return null
+  const today = new Date().toISOString().split('T')[0]
+  let price = unitPrice
+  const labels = []
+  for (const d of activeDiscounts) {
+    if (!d.is_active) continue
+    if (d.applicable_tier !== 'ALL') continue
+    if (d.valid_from && today < d.valid_from) continue
+    if (d.valid_until && today > d.valid_until) continue
+    const matches =
+      d.target_type === 'ALL' ||
+      (d.target_type === 'MENU' && d.menu_item_id === itemId) ||
+      (d.target_type === 'CATEGORY' && d.category_id === categoryId)
+    if (!matches) continue
+    if (d.discount_type === 'PERCENT') {
+      price = Math.round(price * (1 - Number(d.discount_value) / 100))
+      labels.push(`-${d.discount_value}%`)
+    } else {
+      price = Math.max(0, price - Number(d.discount_value))
+      labels.push(`-${Number(d.discount_value).toLocaleString()}원`)
+    }
+  }
+  if (price === unitPrice) return null
+  return { discountedPrice: price, savings: unitPrice - price, label: labels[0] ?? '' }
+}
 
 const CAT_IMAGE = {
   recommended: '/images/sets/F버거 세트.webp',
@@ -91,6 +120,16 @@ export default function MenuScreen({ cart, total, addToCart, updateQty, clearCar
   const itemsPerPage = chatOpen ? COLS : 2 * COLS
   const items        = menuData ? (menuData.menuItems?.[catId] ?? []) : []
   const totalPages   = Math.max(1, Math.ceil(items.length / itemsPerPage))
+
+  // 카트 항목의 categoryId 조회용 (할인 계산에 사용)
+  const menuItemById = useMemo(() => {
+    if (!menuData?.menuItems) return {}
+    const map = {}
+    for (const catItems of Object.values(menuData.menuItems)) {
+      for (const item of catItems) map[item.id] = item
+    }
+    return map
+  }, [menuData])
 
   useEffect(() => {
     setPage(p => Math.min(p, Math.max(0, totalPages - 1)))
@@ -263,7 +302,7 @@ export default function MenuScreen({ cart, total, addToCart, updateQty, clearCar
     )
   }
 
-  const { categories, menuItems, setSides, setDrinks, setSurcharge } = menuData
+  const { categories, menuItems, setSides, setDrinks, setSurcharge, activeDiscounts = [] } = menuData
   const pageItems  = items.slice(page * itemsPerPage, (page + 1) * itemsPerPage)
 
   const handleCat = (id) => { setCatId(id); setPage(0) }
@@ -372,7 +411,12 @@ export default function MenuScreen({ cart, total, addToCart, updateQty, clearCar
         }}>
           {pageItems.map(item => (
             <div key={item.id + '-' + catId} style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-              <FoodCard item={item} onClick={() => handleItemTap(item)} chatOpen={chatOpen} />
+              <FoodCard
+                item={item}
+                onClick={() => handleItemTap(item)}
+                chatOpen={chatOpen}
+                discount={computeItemDiscount(item.id, item.categoryId, item.price, activeDiscounts)}
+              />
             </div>
           ))}
         </div>
@@ -419,9 +463,19 @@ export default function MenuScreen({ cart, total, addToCart, updateQty, clearCar
               overflowY: 'auto',
               transition: 'max-height 0.35s ease',
             }}>
-              {cart.map(item => (
-                <MiniCartItem key={item.cartId} item={item} updateQty={updateQty} chatOpen={chatOpen} />
-              ))}
+              {cart.map(item => {
+                const menuItem = menuItemById[item.id]
+                const disc = computeItemDiscount(item.id, menuItem?.categoryId ?? null, item.unitPrice, activeDiscounts)
+                return (
+                  <MiniCartItem
+                    key={item.cartId}
+                    item={item}
+                    updateQty={updateQty}
+                    chatOpen={chatOpen}
+                    discountedUnitPrice={disc ? disc.discountedPrice : null}
+                  />
+                )
+              })}
             </div>
 
             {/* 합계 + 결제하기 */}
@@ -430,9 +484,26 @@ export default function MenuScreen({ cart, total, addToCart, updateQty, clearCar
               borderTop: '1px solid #f0f0f0',
               display: 'flex', justifyContent: 'space-between', alignItems: 'center',
             }}>
-              <span style={{ fontSize: 24, color: '#888' }}>
-                {t('cartSummary', cart.reduce((s, c) => s + c.qty, 0), cart.reduce((s, c) => s + c.unitPrice * c.qty, 0))}
-              </span>
+              {(() => {
+                const totalQty = cart.reduce((s, c) => s + c.qty, 0)
+                const grossTotal = cart.reduce((s, c) => s + c.unitPrice * c.qty, 0)
+                const discountedTotal = cart.reduce((s, c) => {
+                  const mi = menuItemById[c.id]
+                  const d = computeItemDiscount(c.id, mi?.categoryId ?? null, c.unitPrice, activeDiscounts)
+                  return s + (d ? d.discountedPrice : c.unitPrice) * c.qty
+                }, 0)
+                const hasDis = discountedTotal < grossTotal
+                return (
+                  <span style={{ fontSize: 24, color: '#888' }}>
+                    {t('cartSummary', totalQty, discountedTotal)}
+                    {hasDis && (
+                      <span style={{ fontSize: 16, color: '#e44', fontWeight: 700, marginLeft: 6 }}>
+                        (-{(grossTotal - discountedTotal).toLocaleString()}원)
+                      </span>
+                    )}
+                  </span>
+                )
+              })()}
               <button onClick={() => nav('cart')} style={{
                 background: '#F5B800', color: '#1a1a1a',
                 border: 'none', borderRadius: 15,
@@ -487,7 +558,7 @@ export default function MenuScreen({ cart, total, addToCart, updateQty, clearCar
   )
 }
 
-function MiniCartItem({ item, updateQty, chatOpen }) {
+function MiniCartItem({ item, updateQty, chatOpen, discountedUnitPrice }) {
   const t = useT()
   const compact = !!chatOpen
   const btnSize  = compact ? 36 : 44
@@ -574,7 +645,21 @@ function MiniCartItem({ item, updateQty, chatOpen }) {
         fontSize: compact ? 19 : 24, fontWeight: 700, color: '#222',
         flexShrink: 0, minWidth: compact ? 90 : 120, textAlign: 'right',
       }}>
-        {(item.unitPrice * item.qty).toLocaleString()}{t('won')}
+        {discountedUnitPrice != null && discountedUnitPrice < item.unitPrice ? (
+          <span style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 1 }}>
+            <span style={{
+              fontSize: compact ? 13 : 16, color: '#bbb',
+              textDecoration: 'line-through', fontWeight: 400,
+            }}>
+              {(item.unitPrice * item.qty).toLocaleString()}{t('won')}
+            </span>
+            <span style={{ color: '#e44' }}>
+              {(discountedUnitPrice * item.qty).toLocaleString()}{t('won')}
+            </span>
+          </span>
+        ) : (
+          <>{(item.unitPrice * item.qty).toLocaleString()}{t('won')}</>
+        )}
       </span>
 
       <button onClick={() => updateQty(item.cartId, 0)} style={{
@@ -586,12 +671,15 @@ function MiniCartItem({ item, updateQty, chatOpen }) {
   )
 }
 
-function FoodCard({ item, onClick, chatOpen }) {
+function FoodCard({ item, onClick, chatOpen, discount }) {
   const compact = !!chatOpen
+  const priceFontSize = compact ? 'clamp(11px, 3.0vw, 14px)' : 'clamp(14px, 3.8vw, 17px)'
+  const smallFontSize = compact ? 'clamp(9px, 2.4vw, 11px)' : 'clamp(11px, 3.0vw, 13px)'
   return (
     <button onClick={onClick} style={{
       background: '#ffffff',
-      border: '1px solid #f1f1f1', borderRadius: 16,
+      border: discount ? '1px solid #ffd0d0' : '1px solid #f1f1f1',
+      borderRadius: 16,
       padding: 0, overflow: 'hidden', cursor: 'pointer',
       boxShadow: '0 6px 16px rgba(0,0,0,0.08)',
       display: 'flex', flexDirection: 'column',
@@ -604,6 +692,7 @@ function FoodCard({ item, onClick, chatOpen }) {
         padding: compact ? 4 : 6,
         display: 'flex', alignItems: 'center', justifyContent: 'center',
         borderBottom: '1px solid #f2f2f2',
+        position: 'relative',
       }}>
         {item.image ? (
           <img
@@ -616,6 +705,17 @@ function FoodCard({ item, onClick, chatOpen }) {
             {item.emoji ?? '🍔'}
           </span>
         )}
+        {discount && (
+          <span style={{
+            position: 'absolute', top: 4, right: 4,
+            background: '#e44', color: '#fff',
+            fontSize: smallFontSize, fontWeight: 800,
+            borderRadius: 5, padding: '2px 5px',
+            lineHeight: 1.2,
+          }}>
+            {discount.label}
+          </span>
+        )}
       </div>
       <div style={{ padding: compact ? '6px 8px 7px' : '8px 8px 9px', flexShrink: 0 }}>
         <div style={{
@@ -626,10 +726,26 @@ function FoodCard({ item, onClick, chatOpen }) {
         }}>
           {item.name}
         </div>
-        <div style={{
-          fontSize: compact ? 'clamp(11px, 3.0vw, 14px)' : 'clamp(14px, 3.8vw, 17px)',
-          color: '#744032', textAlign: 'center', fontWeight: 700,
-        }}>{item.price.toLocaleString()}~</div>
+        {discount ? (
+          <div style={{ textAlign: 'center' }}>
+            <div style={{
+              fontSize: smallFontSize, color: '#bbb',
+              textDecoration: 'line-through', lineHeight: 1.2,
+            }}>
+              {item.price.toLocaleString()}원~
+            </div>
+            <div style={{
+              fontSize: priceFontSize, color: '#e44', fontWeight: 800,
+            }}>
+              {discount.discountedPrice.toLocaleString()}원~
+            </div>
+          </div>
+        ) : (
+          <div style={{
+            fontSize: priceFontSize,
+            color: '#744032', textAlign: 'center', fontWeight: 700,
+          }}>{item.price.toLocaleString()}~</div>
+        )}
       </div>
     </button>
   )

--- a/frontend/src/services/cartService.js
+++ b/frontend/src/services/cartService.js
@@ -2,7 +2,7 @@
 // 터치 UI와 음성 주문(LLM)이 동일한 백엔드 카트를 실시간으로 공유한다.
 import { getSessionId } from './session'
 
-const API_BASE = import.meta.env.VITE_API_URL
+const API_BASE = import.meta.env.VITE_API_URL ?? ''
 
 async function req(path, opts) {
   const res = await fetch(`${API_BASE}${path}`, opts)

--- a/frontend/src/services/hardwareService.js
+++ b/frontend/src/services/hardwareService.js
@@ -1,7 +1,7 @@
 // 카드리더/현금수납기 등 물리적 결제 장치 트리거 — 지금은 백엔드(api/hardware.py)가
 // 시뮬레이션만 한다. 나중에 아두이노 등 실제 하드웨어를 연동할 때는 백엔드 내부 구현만
 // 바꾸면 되고, 이 함수의 시그니처·호출부(CartScreen.jsx)는 그대로 유지된다.
-const API_BASE = import.meta.env.VITE_API_URL
+const API_BASE = import.meta.env.VITE_API_URL ?? ''
 
 export async function triggerHardwareAction(action, orderId = null) {
   try {

--- a/frontend/src/services/menuService.js
+++ b/frontend/src/services/menuService.js
@@ -48,6 +48,7 @@ function adaptItem(i, locale) {
   const desc = isKo ? stripNamePrefix(i.description) : parseKcalStr(i.description)
   return {
     id: i.id,
+    categoryId: i.category_id,
     name,
     price: Number(i.base_price),
     kcal: parseKcal(i.description),
@@ -64,8 +65,22 @@ function adaptItem(i, locale) {
   }
 }
 
+export async function fetchActiveDiscounts() {
+  try {
+    const res = await fetch(`${API_BASE}/api/orders/active-discounts`)
+    if (!res.ok) return []
+    return await res.json()
+  } catch {
+    return []
+  }
+}
+
 export async function fetchMenuData(locale = 'ko') {
-  const res = await fetch(`${API_BASE}/api/menu?locale=${encodeURIComponent(locale)}`)
+  const [menuRes, activeDiscounts] = await Promise.all([
+    fetch(`${API_BASE}/api/menu?locale=${encodeURIComponent(locale)}`),
+    fetchActiveDiscounts(),
+  ])
+  const res = menuRes
   if (!res.ok) throw new Error(`menu fetch failed (${res.status})`)
   const raw = await res.json()
 
@@ -97,6 +112,7 @@ export async function fetchMenuData(locale = 'ko') {
   return {
     categories,
     menuItems,
+    activeDiscounts,
     // 세트 사이드/음료 선택 UI는 이름·이미지 표시용으로 menuData.js 상수를 계속 사용한다.
     // (실제 가격·주문 반영은 백엔드의 SET_SIDE/SET_DRINK 옵션이 담당 — 이름 문자열이
     //  backend/core/seed.py 의 시드값과 반드시 동일해야 한다)

--- a/frontend/src/services/menuService.js
+++ b/frontend/src/services/menuService.js
@@ -5,7 +5,7 @@ import { SET_SIDES, SET_DRINKS, SET_SURCHARGE } from '../data/menuData'
 // 이 함수가 백엔드 응답을 화면이 기대하는 { categories, menuItems, setSides, setDrinks, setSurcharge } 로 변환한다.
 // ─────────────────────────────────────────────────────────────────
 
-const API_BASE = import.meta.env.VITE_API_URL
+const API_BASE = import.meta.env.VITE_API_URL ?? ''
 
 // 백엔드 카테고리 키(name_en.lower()) → 프론트 카테고리 id.
 // 여기 없는 카테고리는 name_en.lower() 값을 그대로 id로 쓴다 — 관리자가 새 카테고리를

--- a/frontend/src/services/orderService.js
+++ b/frontend/src/services/orderService.js
@@ -47,6 +47,16 @@ export async function validateCoupon(code, subtotal) {
   return { valid: true, discountAmount: Number(d.discount_amount), finalAmount: Number(d.final_amount) }
 }
 
+export async function fetchActiveDiscounts() {
+  try {
+    const res = await fetch(`${API_BASE}/api/orders/active-discounts`)
+    if (!res.ok) return []
+    return await res.json()
+  } catch {
+    return []
+  }
+}
+
 export async function previewDiscount() {
   try {
     const res = await fetch(`${API_BASE}/api/orders/preview-discount?session_id=${getSessionId()}`)

--- a/frontend/src/services/orderService.js
+++ b/frontend/src/services/orderService.js
@@ -1,6 +1,6 @@
 import { getSessionId } from './session'
 
-const API_BASE = import.meta.env.VITE_API_URL
+const API_BASE = import.meta.env.VITE_API_URL ?? ''
 const ORDER_TYPE_MAP = { 'dine-in': 'EAT_IN', takeout: 'TAKE_OUT' }
 
 async function safeDetail(res) {

--- a/frontend/src/services/orderService.js
+++ b/frontend/src/services/orderService.js
@@ -47,6 +47,17 @@ export async function validateCoupon(code, subtotal) {
   return { valid: true, discountAmount: Number(d.discount_amount), finalAmount: Number(d.final_amount) }
 }
 
+export async function previewDiscount() {
+  try {
+    const res = await fetch(`${API_BASE}/api/orders/preview-discount?session_id=${getSessionId()}`)
+    if (!res.ok) return { discountAmount: 0, applicable: [] }
+    const d = await res.json()
+    return { discountAmount: d.discount_amount, finalAmount: d.final_amount, applicable: d.applicable }
+  } catch {
+    return { discountAmount: 0, applicable: [] }
+  }
+}
+
 export async function getOrderStatus(orderId) {
   const res = await fetch(`${API_BASE}/api/orders/${orderId}`)
   if (!res.ok) throw new Error(`주문 조회 실패 (${res.status})`)

--- a/frontend/src/services/paymentService.js
+++ b/frontend/src/services/paymentService.js
@@ -6,7 +6,7 @@
 // 전부 payPayment 대기화면(바코드/QR 일러스트)으로 수렴하므로 'pay' → QR_PAY 가 가장 근접.
 // ─────────────────────────────────────────────────────────────────
 
-const API_BASE = import.meta.env.VITE_API_URL
+const API_BASE = import.meta.env.VITE_API_URL ?? ''
 const METHOD_MAP = { card: 'CARD', cash: 'CASH', pay: 'QR_PAY' }
 
 export async function processPayment({ orderId, method, amount }) {

--- a/frontend/src/services/pointsService.js
+++ b/frontend/src/services/pointsService.js
@@ -7,7 +7,7 @@
 // /api/user/register 를 거쳐야 한다.
 // ─────────────────────────────────────────────────────────────────
 
-const API_BASE = import.meta.env.VITE_API_URL
+const API_BASE = import.meta.env.VITE_API_URL ?? ''
 
 /**
  * 전화번호로 고객 정보를 조회한다. 미등록(404)이어도 에러를 던지지 않고 registered:false 를

--- a/frontend/src/services/settingsService.js
+++ b/frontend/src/services/settingsService.js
@@ -1,5 +1,5 @@
 // 대기화면 배경 슬라이드 목록 — 관리자가 DB에서 교체/추가/비활성화할 수 있다.
-const API_BASE = import.meta.env.VITE_API_URL
+const API_BASE = import.meta.env.VITE_API_URL ?? ''
 
 const FALLBACK_IMAGES = ['/bg.png']
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -43,6 +43,7 @@ export default defineConfig(({ mode }) => {
         input: {
           main:   fileURLToPath(new URL('./index.html', import.meta.url)),
           signup: fileURLToPath(new URL('./signup.html', import.meta.url)),
+          admin:  fileURLToPath(new URL('./admin.html', import.meta.url)),
         },
         onwarn(warning, warn) {
           if (warning.code === 'SOURCEMAP_ERROR') return
@@ -63,6 +64,7 @@ export default defineConfig(({ mode }) => {
         '/ws': { target: 'ws://localhost:8000', ws: true },
         '/api': { target: 'http://localhost:8000' },
         '/ai_modules': { target: 'http://localhost:8000' },
+        '/static': { target: 'http://localhost:8000' },
       },
     },
   }


### PR DESCRIPTION
## Summary

### 관리자 페이지
- 메뉴 관리 전면 개편: 세트 구성 일괄 편집 탭, 카테고리 생성/수정/삭제, 메뉴 삭제 기능 추가
- 품절 토글 시 페이지 깜박임·스크롤 초기화·열 너비 변동 수정 (optimistic update + table-layout fixed)
- 카테고리 숨김 토글 시 목록에서 사라지는 버그 수정 (관리자 전용 API 분리)
- 주문 관리 테이블에 경과 시간 컬럼 추가 (접수/조리중 상태만 색상 표시: 연두→노랑→주황→빨강)
- 주문 관리 테이블 열 너비 고정 (상태 변경 버튼 길이에 따른 폭 변동 수정)
- 대시보드 로고 → `logo.png` 적용, 매출 추이 라인/바 차트 전환 토글 추가
- 할인 생성 모달에 카테고리/메뉴 선택 UI 추가 (기존에는 ALL 타입만 생성 가능했던 버그 수정)

### 키오스크
- 쿠폰 사용 흐름 개선: 스캔/입력 → 쿠폰 내용 확인 → "사용하기" 버튼으로 최종 적용
- 정액 쿠폰 최소 금액 조건 적용, 쿠폰 금액 = 결제 금액 시 0원 결제 완료 처리
- 쿠폰 할인 금액을 결제 대기 팝업에 반영
- 세트 메뉴 추가금(오렌지주스·양념감자튀김 +500원) 복원

### 백엔드
- `GET /api/admin/menu` 신설 (숨김 카테고리·품절 메뉴 포함한 관리자 전용 조회)
- `GET /api/admin/set-options` / `PATCH /api/admin/set-options` 신설 (세트 구성 일괄 편집)
- Discount 테이블을 주문 생성 시 실제 계산에 반영 (ALL/CATEGORY/MENU 타입 지원)
- `GET /api/orders/preview-discount` 신설 (주문 생성 전 할인 미리보기)
- `discount_dao.py` import 경로 수정 및 `get_active_discounts` 함수 추가

## Test plan

- [ ] 메뉴 관리 > 세트 구성 탭에서 사이드/음료 추가금 수정 후 저장 확인
- [ ] 카테고리 숨김 토글 → 목록에서 사라지지 않고 Toggle 상태만 변경 확인
- [ ] 품절 토글 시 스크롤·폭 변동 없이 즉시 반영 확인
- [ ] 주문 관리 > 접수/조리중 주문에 경과 시간 색상 배지 표시 확인
- [ ] 쿠폰 스캔 → 쿠폰 확인 화면 → "사용하기" → 결제 팝업에 할인 금액 반영 확인
- [ ] 활성 할인 등록 후 주문 생성 시 `discount_amount`에 반영되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)